### PR TITLE
Add libdirs property to set the linker search path.

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -170,14 +170,24 @@ could do
 
 
 Similarly, any non trivial project usually links with some external libraries.
-To specify these libraries, you need to assign to the ``libs``
-property:
+To specify these libraries, you need to assign to the ``libs`` property and
+also may need to set ``libdirs`` if these libraries are not present in the
+standard search path:
 
 .. code-block:: bkl
 
     exe hello {
-        libs = foo;
+        libdirs = ../3rdparty/somelib/lib;
+        libs = somelib;
     }
+
+Notice that you only need to do the latter if the libraries are not built as
+part of the same project, otherwise you should simply list them as
+dependencies as shown in the next section.
+
+And if you need to use any other linker option you can specify it using
+``link-options`` property. As with compiler options, you would normally test
+for the toolkit before doing it as linker options are toolset-specific.
 
 
 Multiple Modules

--- a/extras/vim/bkl.vim
+++ b/extras/vim/bkl.vim
@@ -49,7 +49,7 @@ syn keyword	bklLibProp	libname contained
 " exe/lib/dll ones.
 syn keyword	bklBuildProp	archs configurations contained
 syn keyword	bklBuildProp	compiler-options c-compiler-options cxx-compiler-options contained
-syn keyword	bklBuildProp	defines headers includedirs libs link-options outputdir sources contained
+syn keyword	bklBuildProp	defines headers includedirs libdirs libs link-options outputdir sources contained
 
 syn keyword	bklBool 	false true contained
 syn region	bklBoolRHS	matchgroup=Normal start="= *" end=";" contains=bklBool contained

--- a/src/bkl/plugins/gnu.py
+++ b/src/bkl/plugins/gnu.py
@@ -164,6 +164,9 @@ class GnuLinker(GnuFileCompiler):
 
     def _linker_flags(self, toolset, target):
         cmd = self._arch_flags(toolset, target)
+        libdirs = target["libdirs"]
+        if libdirs:
+            cmd += bkl.expr.add_prefix("-L", libdirs)
         libs, ldlibs = target.type.get_all_libs(toolset, target)
         cmd += libs
         cmd += bkl.expr.add_prefix("-l", ListExpr(ldlibs)).items

--- a/src/bkl/plugins/native.py
+++ b/src/bkl/plugins/native.py
@@ -213,6 +213,11 @@ class NativeCompiledType(TargetType):
 
 class NativeLinkedType(NativeCompiledType):
     properties = [
+            Property("libdirs",
+                 type=ListType(PathType()),
+                 default=[],
+                 inheritable=True,
+                 doc="Additional directories where to look for libraries."),
             Property("link-options",
                  type=ListType(StringType()),
                  default=[],

--- a/src/bkl/plugins/vs200x.py
+++ b/src/bkl/plugins/vs200x.py
@@ -329,6 +329,10 @@ class VS200xToolsetBase(VSToolsetBase):
         if libs:
             n["AdditionalDependencies"] = VSList(" ", ("%s.lib" % x.as_py() for x in libs))
 
+        libdirs = cfg["libdirs"]
+        if libdirs:
+            n["AdditionalLibraryDirectories"] = VSList(";", libdirs)
+
         targetname = cfg[target.type.basename_prop]
         if targetname != target.name:
             n["OutputFile"] = concat("$(OutDir)\\", targetname, ".", target.type.target_file(self, target).get_extension())

--- a/src/bkl/plugins/vs2010.py
+++ b/src/bkl/plugins/vs2010.py
@@ -193,6 +193,10 @@ class VS201xToolsetBase(VSToolsetBase):
                 n_link.add("EnableCOMDATFolding", True)
                 n_link.add("OptimizeReferences", True)
             if not is_library(target):
+                libdirs = VSList(";", cfg["libdirs"])
+                if libdirs:
+                    libdirs.append("%(AdditionalLibraryDirectories)")
+                    n_link.add("AdditionalLibraryDirectories", libdirs)
                 ldflags = VSList(" ", cfg["link-options"])
                 if ldflags:
                     ldflags.append("%(AdditionalOptions)")


### PR DESCRIPTION
This is similar to includedirs for the C/C++ compiler and allows to specify
the library search path in a portable way.
