### PR TITLE
Add --diff-only option to only see changes to the generated files.

### DIFF
--- a/src/bkl/io.py
+++ b/src/bkl/io.py
@@ -37,6 +37,9 @@ logger = logging.getLogger("bkl.io")
 # Set to true to prevent any output from being written
 dry_run = False
 
+# Set to true to show diff with the existing file instead of updating it
+diff_only = False
+
 # Set to true to force writing of output files, even if they exist and would be
 # unchanged. In other words, always touch output files. This is useful for
 # makefiles that support automatic regeneration.
@@ -113,6 +116,15 @@ class OutputFile(object):
             if old == self.text:
                 status = "."
                 logger.info("%s\t%s", status, rel_fn)
+                return
+            if diff_only:
+                import sys
+                from difflib import unified_diff
+                for line in unified_diff(old.splitlines(True) if old is not None else [],
+                                         self.text.splitlines(True),
+                                         os.path.normpath(os.path.join("old", self.filename)),
+                                         os.path.normpath(os.path.join("new", self.filename))):
+                    sys.stdout.write(line)
                 return
         else:
             old = None

--- a/src/tool.py
+++ b/src/tool.py
@@ -90,6 +90,10 @@ parser.add_option(
         action="store_true", dest="dry_run", default=False,
         help="don't write any files, just pretend to do it")
 parser.add_option(
+        "", "--diff-only",
+        action="store_true", dest="diff_only", default=False,
+        help="only output diffs instead of modiyfing the files, implies --dry-run")
+parser.add_option(
         "", "--force",
         action="store_true", dest="force", default=False,
         help="touch output files even if they're unchanged")
@@ -129,6 +133,9 @@ else:
     log_level = logging.WARNING
 logger.setLevel(log_level)
 
+if options.diff_only and options.force:
+    sys.stderr.write("--diff-only and --force option can't be used together\n")
+    sys.exit(3)
 
 # note: we intentionally import bakefile this late so that the logging
 # module is already initialized
@@ -140,6 +147,7 @@ import bkl.io
 try:
     start_time = time()
     bkl.io.dry_run = options.dry_run
+    bkl.io.diff_only = options.diff_only
     bkl.io.force_output = options.force
     if options.dump:
         intr = bkl.dumper.DumpingInterpreter()


### PR DESCRIPTION
This is mostly useful when developing bakefile itself but could be also used
to check if the changes really have the expected effect in normal use too.

The diff is currently in simple unified format with default context and no
colours (but https://pypi.python.org/pypi/cdiff can be used with it).
