### PR TITLE
Don't output boolean macros in GNU makefiles unless they are really needed

### DIFF
--- a/src/bkl/io.py
+++ b/src/bkl/io.py
@@ -99,6 +99,16 @@ class OutputFile(object):
             text = text.encode(self.charset)
         self.text += text
 
+    def replace(self, placeholder, value):
+        """
+        Replaces the value of the given placeholder with its real value. This
+        is useful for parts of the output which are not known at the time they
+        are written because they depend on other parts coming after them.
+
+        Notice that only the first occurrency of the placeholder is replaced.
+        """
+        self.text = self.text.replace(placeholder, value, 1)
+
     def commit(self):
         if self.eol == EOL_WINDOWS:
             self.text = self.text.replace("\n", "\r\n")

--- a/src/bkl/makefile.py
+++ b/src/bkl/makefile.py
@@ -207,7 +207,7 @@ class MakefileToolset(Toolset):
                 model=module)
 
         mk_fmt = self.Formatter()
-        expr_fmt = self.ExprFormatter(paths_info)
+        expr_fmt = self.ExprFormatter(self, paths_info)
 
         f = io.OutputFile(output, io.EOL_UNIX, creator=self, create_for=module)
         self.on_header(f, module)


### PR DESCRIPTION
This is a cosmetic change which omits the macro definitions if they are not
used in the rest of the makefile.
