### PR TITLE
Allow using settings with MSVS backends.

### DIFF
--- a/docs/language.rst
+++ b/docs/language.rst
@@ -590,7 +590,8 @@ and just hard-code their values when you don't need the flexibility.
 
 .. note::
 
-   Settings are currently only supported by makefiles.
+   Settings are currently only fully supported by makefiles, they are always
+   replaced with their default values in the project files.
 
 
 Submodules

--- a/src/bkl/plugins/vs200x.py
+++ b/src/bkl/plugins/vs200x.py
@@ -105,8 +105,8 @@ class VS200xXmlFormatter(XmlFormatter):
     indent_step = "\t"
     ExprFormatter = VS200xExprFormatter
 
-    def __init__(self, paths_info):
-        super(VS200xXmlFormatter, self).__init__(paths_info, charset=VCPROJ_CHARSET)
+    def __init__(self, settings, paths_info):
+        super(VS200xXmlFormatter, self).__init__(settings, paths_info, charset=VCPROJ_CHARSET)
 
     # these are always written as <foo>\n<foo>, not <foo/>
     elems_not_collapsed = set(["References",
@@ -253,7 +253,7 @@ class VS200xToolsetBase(VSToolsetBase):
 
         f = OutputFile(filename, EOL_WINDOWS, charset=VCPROJ_CHARSET,
                        creator=self, create_for=target)
-        f.write(self.XmlFormatter(paths_info).format(root))
+        f.write(self.XmlFormatter(target.project.settings, paths_info).format(root))
         f.commit()
 
 

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -348,7 +348,7 @@ class VS201xToolsetBase(VSToolsetBase):
         filename = project.projectfile.as_native_path_for_output(target)
         paths_info = self.get_project_paths_info(target, project)
 
-        formatter= XmlFormatter(paths_info)
+        formatter = XmlFormatter(target.project.settings, paths_info)
         f = OutputFile(filename, EOL_WINDOWS,
                        creator=self, create_for=target)
         f.write(codecs.BOM_UTF8)


### PR DESCRIPTION
Unless I'm missing something obvious, this is all we need to allow trivial use of settings with the projects.

What bothers me is that there is no way to check that I updated all occurrences of the ctors with the new parameter and I'm not sure if I found all of them (the indirect use of `XmlFormatter` and such doesn't make it easy), please check if I didn't forget something. TIA!
