### PR TITLE
Don't allow undefined symbols in loadable modules in gnu toolset.

### DIFF
--- a/src/bkl/plugins/gnu.py
+++ b/src/bkl/plugins/gnu.py
@@ -370,7 +370,7 @@ class GnuToolset(MakefileToolset):
     shared_library_link_flag = "-shared"
     loadable_module_prefix = ""
     loadable_module_extension = "so"
-    loadable_module_link_flag = "-shared"
+    loadable_module_link_flag = "-shared -Wl,-z,defs"
 
     deps_flags = GCC_DEPS_FLAGS
     pic_flags = "-fPIC -DPIC"
@@ -477,7 +477,7 @@ class SunCCGnuToolset(GnuToolset):
     default_cxx = "sunCC"
 
     shared_library_link_flag  = "-G -pic"
-    loadable_module_link_flag = "-G -pic"
+    loadable_module_link_flag = "-G -pic -z defs"
 
     deps_flags = "-xMD"
     pic_flags = "-pic -DPIC"


### PR DESCRIPTION
Link loadable modules with "-z defs" flag to ensure that the created shared
object can really be loaded.

While it can be useful to create loadable modules with unresolved symbols
(e.g. to bind to the symbols defined in the program loading them), this
doesn't work currently under neither Windows (where it is not possible at all)
nor OS X (where we'd need to use "-undefined dynamic_lookup" to make it
possible), so make gnu toolset behaviour consistent with them and more useful
by default. If this proves to be too limiting in the future, we can always add
"allow-undefined" option later.
