### PR TITLE
Don't allow undefined symbols in neither modules nor shared libraries.

### DIFF
--- a/src/bkl/plugins/gnu.py
+++ b/src/bkl/plugins/gnu.py
@@ -367,7 +367,7 @@ class GnuToolset(MakefileToolset):
     library_extension = "a"
     shared_library_prefix = "lib"
     shared_library_extension = "so"
-    shared_library_link_flag = "-shared"
+    shared_library_link_flag = "-shared -Wl,-z,defs"
     loadable_module_prefix = ""
     loadable_module_extension = "so"
     loadable_module_link_flag = "-shared -Wl,-z,defs"
@@ -476,7 +476,7 @@ class SunCCGnuToolset(GnuToolset):
     default_cc = "suncc"
     default_cxx = "sunCC"
 
-    shared_library_link_flag  = "-G -Kpic"
+    shared_library_link_flag  = "-G -Kpic -z defs"
     loadable_module_link_flag = "-G -Kpic -z defs"
 
     deps_flags = "-xMD"


### PR DESCRIPTION
I completely forgot that I never updated #25, so I've updated it now with the change you suggested. Unfortunately I've (semi-)accidentally deleted the old branch and recreating it immediately afterwards is apparently not sufficient to reopen that PR, so I'm opening a new one.
