### PR TITLE
Allow lists to be used inside strings

### DIFF
--- a/src/bkl/expr.py
+++ b/src/bkl/expr.py
@@ -55,7 +55,7 @@ class Expr(object):
     """
     def __init__(self, pos=None):
         self.pos = pos
-    
+
     def is_const(self):
         """
         Returns true if the expression is constant, i.e. can be evaluated
@@ -176,7 +176,7 @@ class ConcatExpr(Expr):
 
     def as_py(self):
         items = (i.as_py() for i in self.items)
-        return "".join(i for i in items if i is not None)
+        return "".join(i if not isinstance(i, list) else " ".join(i) for i in items if i is not None)
 
     def __nonzero__(self):
         for i in self.items:
@@ -336,7 +336,7 @@ class BoolExpr(Expr):
         self.operator = operator
         self.left = left
         self.right = right
-    
+
     def has_bool_operands(self):
         """
         Returns true if the operator is such that it requires boolean operands

--- a/src/bkl/vartypes.py
+++ b/src/bkl/vartypes.py
@@ -170,7 +170,11 @@ class StringType(Type):
               # paths etc. can be used as strings too
               not isinstance(e, expr.BoolExpr) and
               not isinstance(e, expr.PathExpr)):
-            raise TypeError(self, e)
+            if isinstance(e, expr.ListExpr):
+                for i in e.items:
+                    self.validate(i)
+            else:
+                raise TypeError(self, e)
 
 
 class IdType(Type):


### PR DESCRIPTION
Fixes #33. Also, I apologize for the removal of indentation in expr.py. Blame my text editor.
