### PR TITLE
Check for .git existence, not whether it's a directory.

### DIFF
--- a/src/bkl/version.py
+++ b/src/bkl/version.py
@@ -30,7 +30,9 @@ def get_version():
     # version if we do:
     import os.path
     gitdir = os.path.join(os.path.dirname(__file__), "../../.git")
-    if os.path.isdir(gitdir):
+    # notice that we intentionally use exists() and not isdir() as thie git
+    # "directory" is actually a file inside a git submodule
+    if os.path.exists(gitdir):
         import subprocess
         try:
             # TODO-2.6: replace this with subprocess.check_output() once we


### PR DESCRIPTION
I think this is the right thing to do when using bakefile as a submodule, but would appreciate a confirmation that I'm not missing something here.

---

This ensures that correct (i.e. git tags-based) version detection is also used
when bakefile repository is a submodule inside some other git repository as
.git is a file and not a directory in this case.
