### PR TITLE
Avoid spurious "unused variable" warnings for some settings.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ Bug fixes
 - Changing variable appearing in "source" statement of a base template
   from the derived target now works as expected.
 - Simplify paths involving $(builddir) in the "gnu" toolset output.
+- Don't give spurious "unused variable" warnings for conditionally defined
+  settings.
 
 
 v1.2.5 (2014-07-28)

--- a/src/bkl/expr.py
+++ b/src/bkl/expr.py
@@ -214,6 +214,10 @@ class PlaceholderExpr(Expr):
     In particular, it is used for the "toolset" property before the model is split into
     toolset-specific copies, to allow partial evaluation common to all of them.
 
+    It is also used together with artificial variables to represent settings.
+    For placeholders used for this purpose, :meth:`get_associated_variable()`
+    can be used to retrieve the associated variable object.
+
     .. attribute:: var
 
        Name of referenced setting (e.g. "config" or "toolset").
@@ -221,9 +225,24 @@ class PlaceholderExpr(Expr):
     def __init__(self, var, pos=None):
         super(PlaceholderExpr, self).__init__(pos)
         self.var = var
+        self.associated_variable = None
 
     def as_py(self):
         raise NonConstError(self)
+
+    def set_associated_variable(self, associated_variable):
+        """
+        Sets the associated variable object for placeholders used for settings
+        values.
+        """
+        self.associated_variable = associated_variable
+
+    def get_associated_variable(self):
+        """
+        Returns the associated variable object if this placeholder is used for
+        a setting value, returns None otherwise.
+        """
+        return self.associated_variable
 
     def __str__(self):
         return "${%s}" % self.var

--- a/src/bkl/interpreter/analyze.py
+++ b/src/bkl/interpreter/analyze.py
@@ -101,10 +101,14 @@ class _UsedVariablesTracker(Visitor):
     path = Visitor.visit_children
     bool = Visitor.visit_children
     if_ = Visitor.visit_children
-    placeholder = Visitor.noop
+
+    def placeholder(self, e):
+        self._track_var(e.get_associated_variable())
 
     def reference(self, e):
-        var = e.get_variable()
+        self._track_var(e.get_variable())
+
+    def _track_var(self, var):
         if var is not None and not var.is_property:
             self.used_vars.add(id(var))
 

--- a/src/bkl/interpreter/builder.py
+++ b/src/bkl/interpreter/builder.py
@@ -382,14 +382,19 @@ class Builder(object, CondTrackingMixin):
         # This is for a dummy variable created at project scope and referencing
         # the setting. By doing this, it's easy to reference settings as ordinary
         # variables.
-        var_value = PlaceholderExpr(name, pos=node.pos)
+        placeholder = PlaceholderExpr(name, pos=node.pos)
 
         if self.active_if_cond is not None:
             cond = self.active_if_cond
             setting.set_property_value("_condition", cond)
-            var_value = IfExpr(cond, yes=var_value, no=NullExpr(), pos=node.pos)
+            var_value = IfExpr(cond, yes=placeholder, no=NullExpr(), pos=node.pos)
+        else:
+            var_value = placeholder
 
-        project.add_variable(Variable(name, var_value))
+        variable = Variable(name, var_value)
+        placeholder.set_associated_variable(variable)
+
+        project.add_variable(variable)
         # set any properties on the setting object:
         self.handle_children(node.content, setting)
 


### PR DESCRIPTION
A special artificial variable is created for each setting to make it possible
to reference it easier, however this variable itself is only referenced from a
PlaceholderExpr which wasn't checked for variable references before, resulting
in "unused variable" warnings being wrongly given.

Fix this by handling PlaceholderExpr correctly in _UsedVariablesTracker.
