### PR TITLE
Fix clean commands when using build directory with gnu backend.

### DIFF
--- a/src/bkl/makefile.py
+++ b/src/bkl/makefile.py
@@ -349,7 +349,8 @@ class MakefileToolset(Toolset):
 
     def _get_clean_commands(self, mk_fmt, expr_fmt, graphs, submakefiles):
         for e in self.autoclean_extensions:
-            yield "%s *.%s" % (self.del_command, e)
+            p = expr.PathExpr([expr.LiteralExpr("*." + e)], expr.ANCHOR_BUILDDIR)
+            yield "%s %s" % (self.del_command, expr_fmt.format(p))
         for g in graphs:
             for node in g.all_nodes():
                 for f in node.outputs:


### PR DESCRIPTION
The files with auto-cleaned extensions are generated in the build directory,
not the source one, so remove them from there.

---

This is hopefully less controversial and is independent of the other changes: just remove the files in the correct directory.
