### PR TITLE
Fix SWIG interface file (0.2 branch)

### DIFF
--- a/src/bkl_c.i
+++ b/src/bkl_c.i
@@ -42,6 +42,8 @@
         return NULL;
 }
 
+%inline %{
+
 /* Tokenizes input string \a expr that may contain Python expressions
    inside $(...) and calls \a textCallb(\a moreArgs, text)
    for text parts (outside $(...)) and
@@ -91,6 +93,8 @@ extern PyObject *proxydict_create(void);
 extern void proxydict_hijack(PyObject *data, PyObject *dict);
 /* add new dictionary to the proxy: */
 extern void proxydict_add(PyObject *data, PyObject *dict);
+
+%}
 
 %pythoncode %{
 class ProxyDictionary:


### PR DESCRIPTION
Currently, The (generated) SWIG wrapper file (`src/bkl_c_wrap.c`) doesn't contain the declaration of `doEvalExpr`, `proxydict_create`, etc.  Then, the compiler assumes that the argument types and return type of these functions are `int`s, so the program fails with a segmentation fault on LP64 environments.

Surrounding the declarations in `src/bkl_c.i` by `%inline %{` and `%}` fixes this problem.
