### PR TITLE
Generate correct warning options for "suncc" backend.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,5 @@
+- Generate correct warning options for "suncc" backend.
+
 v1.2.5 (2014-07-28)
 ===================
 

--- a/src/bkl/plugins/gnu.py
+++ b/src/bkl/plugins/gnu.py
@@ -144,11 +144,11 @@ class GnuCCompiler(GnuFileCompiler):
             cmd.append(LiteralExpr(toolset.pthread_cc_flags))
         cmd += bkl.expr.add_prefix("-D", target["defines"])
         cmd += bkl.expr.add_prefix("-I", target["includedirs"])
-        if target["warnings"] == "no":
-            cmd.append(LiteralExpr("-w"))
-        elif target["warnings"] == "all":
-            cmd.append(LiteralExpr("-Wall"))
-        #else: don't do anything special for "minimal" and "default"
+
+        warning_flags = toolset.warning_flags[str(target["warnings"])]
+        if warning_flags is not None:
+            cmd.append(LiteralExpr(warning_flags))
+
         cmd += target["compiler-options"]
         cmd += target[self._options_prop_name]
         # FIXME: use a parser instead of constructing the expression manually
@@ -379,6 +379,13 @@ class GnuToolset(MakefileToolset):
     soname_flags = "-Wl,-soname,$(notdir $@)"
     extra_link_flags = None
 
+    warning_flags = {
+        "no":       "-w",
+        "minimal":  None,
+        "default":  None,
+        "all":      "-Wall",
+    }
+
     def output_default_flags(self, file, configs):
         """
             Helper of on_header() which outputs default, config-dependent,
@@ -557,3 +564,10 @@ class SunCCGnuToolset(GnuToolset):
     soname_flags = "-h $(notdir $@)"
     # FIXME: Do this for C++ only
     extra_link_flags = "-lCstd -lCrun"
+
+    warning_flags = {
+        "no":       "-w",
+        "minimal":  None,
+        "default":  "+w",
+        "all":      "+w2 -xport64",
+    }


### PR DESCRIPTION
Don't use "-Wall" which is not understood by this compiler.

Closes #53.