### PR TITLE
Add "max" warnings level and restore "all" to mean /W4 for MSVS

### DIFF
--- a/src/bkl/plugins/gnu.py
+++ b/src/bkl/plugins/gnu.py
@@ -407,6 +407,7 @@ class GnuToolset(MakefileToolset):
         "minimal":  None,
         "default":  None,
         "all":      "-Wall",
+        "max":      "-Wall -Wextra", # Not really max, more could be added.
     }
 
     def output_default_flags(self, file, configs):
@@ -652,5 +653,6 @@ class SunCCGnuToolset(GnuToolset):
         "no":       "-w",
         "minimal":  None,
         "default":  "+w",
-        "all":      "+w2 -xport64",
+        "all":      "+w2 -xport64=implicit",
+        "max":      "+w2 -xport64=full",
     }

--- a/src/bkl/plugins/native.py
+++ b/src/bkl/plugins/native.py
@@ -58,15 +58,16 @@ class NativeCompiledType(TargetType):
                  inheritable=True,
                  doc="Directories where to look for header files."),
             Property("warnings",
-                 type=EnumType("warnings", ["no", "minimal", "default", "all"]),
+                 type=EnumType("warnings", ["no", "minimal", "default", "all", "max"]),
                  default="default",
                  inheritable=True,
                  doc="""
                      Warning level for the compiler.
 
                      Use ``no`` to completely disable warning, ``minimal`` to
-                     show only the most important warning messages or ``all``
-                     to enable all warnings.
+                     show only the most important warning messages, ``all``
+                     to enable all warnings that usually don't result in false
+                     positives and ``max`` to enable absolutely all warnings.
                      """),
             Property("compiler-options",
                  type=ListType(StringType()),

--- a/src/bkl/plugins/vs200x.py
+++ b/src/bkl/plugins/vs200x.py
@@ -580,7 +580,9 @@ class VS200xToolsetBase(VSToolsetBase):
         WARNING_LEVELS = { "no": 0,
                            "minimal": 1,
                            "default": 3,
-                           "all": 4 }
+                           "all": 4,
+                           "max": 4,
+                         }
         return WARNING_LEVELS[cfg["warnings"].as_py()]
 
 

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -481,13 +481,15 @@ class VS201xToolsetBase(VSToolsetBase):
 
     def get_vs_warning_level(self, cfg):
         """
-        Return numeric MSVS warning level corresponding to the warning option
-        in the specified config.
+        Return MSVS warning level option value corresponding to the warning
+        option in the specified config.
         """
         WARNING_LEVELS = { "no": "TurnOffAllWarnings",
                            "minimal": "Level1",
                            "default": "Level3",
-                           "all": "EnableAllWarnings" }
+                           "all": "Level4",
+                           "max": "EnableAllWarnings",
+        }
         return WARNING_LEVELS[cfg["warnings"].as_py()]
 
 


### PR DESCRIPTION
Partially revert the changes of 7716c419b1617a360c3d38ffd1ab41bccd0bcd61 and
map "warnings = all" to "/W4" in MSVS projects as "EnableAllWarnings" is
unusable in practice, generating hundreds of warnings in the standard headers.

Still allow using it if the new "max" warnings level is specified and update
the other compilers to try to generate as many warnings as possible for this
level.