### PR TITLE
Remove some trivial differences in VS201x backend

### DIFF
--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -62,6 +62,9 @@ class VS2010Project(VSProjectBase):
 class VS201xToolsetBase(VSToolsetBase):
     """Base class for VS2010, VS2012, VS2013 and VS2015 toolsets."""
 
+    #: XML formatting class
+    XmlFormatter = VS201xXmlFormatter
+
     #: Extension of format files
     proj_extension = "vcxproj"
 
@@ -359,7 +362,7 @@ class VS201xToolsetBase(VSToolsetBase):
         filename = project.projectfile.as_native_path_for_output(target)
         paths_info = self.get_project_paths_info(target, project)
 
-        formatter = VS201xXmlFormatter(target.project.settings, paths_info)
+        formatter = self.XmlFormatter(target.project.settings, paths_info)
         f = OutputFile(filename, EOL_WINDOWS,
                        creator=self, create_for=target)
         f.write(codecs.BOM_UTF8)

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -32,6 +32,16 @@ from bkl.plugins.vsbase import *
 from bkl.expr import concat, format_string
 
 
+class VS201xXmlFormatter(XmlFormatter):
+    """
+    XmlFormatter for VS 201x output.
+    """
+
+    elems_not_collapsed = set(["ImportGroup"])
+
+    def __init__(self, settings, paths_info):
+        super(VS201xXmlFormatter, self).__init__(settings, paths_info)
+
 # TODO: Put more content into this class, use it properly
 class VS2010Project(VSProjectBase):
     """
@@ -348,7 +358,7 @@ class VS201xToolsetBase(VSToolsetBase):
         filename = project.projectfile.as_native_path_for_output(target)
         paths_info = self.get_project_paths_info(target, project)
 
-        formatter = XmlFormatter(target.project.settings, paths_info)
+        formatter = VS201xXmlFormatter(target.project.settings, paths_info)
         f = OutputFile(filename, EOL_WINDOWS,
                        creator=self, create_for=target)
         f.write(codecs.BOM_UTF8)

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -274,39 +274,40 @@ class VS201xToolsetBase(VSToolsetBase):
             root.add(n)
 
         # Source files:
-        items = Node("ItemGroup")
-        root.add(items)
-        cl_files_map = bkl.compilers.disambiguate_intermediate_file_names(cl_files)
-        for sfile in cl_files:
-            if sfile["compile-commands"]:
-                self._add_custom_build_file(items, sfile)
-            else:
-                ext = sfile.filename.get_extension()
-                # TODO: share this code with VS200x
-                # FIXME: make this more solid
-                if ext in ['cpp', 'cxx', 'cc', 'c']:
-                    n_cl_compile = Node("ClCompile", Include=sfile.filename)
+        if cl_files:
+            items = Node("ItemGroup")
+            root.add(items)
+            cl_files_map = bkl.compilers.disambiguate_intermediate_file_names(cl_files)
+            for sfile in cl_files:
+                if sfile["compile-commands"]:
+                    self._add_custom_build_file(items, sfile)
                 else:
-                    # FIXME: handle both compilation into cpp and c files
-                    genfiletype = bkl.compilers.CxxFileType.get()
-                    genname = bkl.expr.PathExpr([bkl.expr.LiteralExpr(sfile.filename.get_basename())],
-                                                bkl.expr.ANCHOR_BUILDDIR,
-                                                pos=sfile.filename.pos).change_extension("cpp")
+                    ext = sfile.filename.get_extension()
+                    # TODO: share this code with VS200x
+                    # FIXME: make this more solid
+                    if ext in ['cpp', 'cxx', 'cc', 'c']:
+                        n_cl_compile = Node("ClCompile", Include=sfile.filename)
+                    else:
+                        # FIXME: handle both compilation into cpp and c files
+                        genfiletype = bkl.compilers.CxxFileType.get()
+                        genname = bkl.expr.PathExpr([bkl.expr.LiteralExpr(sfile.filename.get_basename())],
+                                                    bkl.expr.ANCHOR_BUILDDIR,
+                                                    pos=sfile.filename.pos).change_extension("cpp")
 
-                    ft_from = bkl.compilers.get_file_type(ext)
-                    compiler = bkl.compilers.get_compiler(self, ft_from, genfiletype)
+                        ft_from = bkl.compilers.get_file_type(ext)
+                        compiler = bkl.compilers.get_compiler(self, ft_from, genfiletype)
 
-                    customBuild = Node("CustomBuild", Include=sfile.filename)
-                    customBuild.add("Command", VSList("\n", compiler.commands(self, target, sfile.filename, genname)))
-                    customBuild.add("Outputs", genname)
-                    items.add(customBuild)
-                    n_cl_compile = Node("ClCompile", Include=genname)
-                # Handle files with custom object name:
-                if sfile in cl_files_map:
-                    n_cl_compile.add("ObjectFileName",
-                                     concat("$(IntDir)\\", cl_files_map[sfile], ".obj"))
-                self._add_per_file_options(sfile, n_cl_compile)
-                items.add(n_cl_compile)
+                        customBuild = Node("CustomBuild", Include=sfile.filename)
+                        customBuild.add("Command", VSList("\n", compiler.commands(self, target, sfile.filename, genname)))
+                        customBuild.add("Outputs", genname)
+                        items.add(customBuild)
+                        n_cl_compile = Node("ClCompile", Include=genname)
+                    # Handle files with custom object name:
+                    if sfile in cl_files_map:
+                        n_cl_compile.add("ObjectFileName",
+                                         concat("$(IntDir)\\", cl_files_map[sfile], ".obj"))
+                    self._add_per_file_options(sfile, n_cl_compile)
+                    items.add(n_cl_compile)
 
         # Headers files:
         if target.headers:

--- a/src/bkl/plugins/vsbase.py
+++ b/src/bkl/plugins/vsbase.py
@@ -118,7 +118,7 @@ class Node(object):
         >>> n.add("LinkIncremental", target["vs-incremental-link"])
 
         Or it can take the same arguments that Node constructor takes; this is
-        equivalent to creating a Node using the same arguments and than adding
+        equivalent to creating a Node using the same arguments and then adding
         it using the first form of add():
         >>> n.add("ImportGroup", Label="PropertySheets")
         """
@@ -293,7 +293,7 @@ class XmlFormatter(object):
         # a specialization of int and dictionaries don't differentiate between
         # them and so @memoized format_value() would incorrectly return the
         # same value (e.g. "1") for both True and 1. The dummy 'valtype'
-        # argument disambiguates these cases, with no noticeable lost of
+        # argument disambiguates these cases, with no noticeable loss of
         # performance.
         return self._format_value(val, type(val))
 

--- a/src/bkl/plugins/vsbase.py
+++ b/src/bkl/plugins/vsbase.py
@@ -230,6 +230,9 @@ class XmlFormatter(object):
     #: Class for expressions formatting
     ExprFormatter = VSExprFormatter
 
+    #: Elements which are written in full form when empty.
+    elems_not_collapsed = set()
+
     def __init__(self, settings, paths_info, charset="utf-8"):
         self.charset = charset
         self.expr_formatter = self.ExprFormatter(settings, paths_info)
@@ -275,17 +278,49 @@ class XmlFormatter(object):
         arguments already use properly escaped markup; values in *attrs* are
         quoted and escaped.
         """
-        s = ["%s<%s" % (indent, name)]
+        s = "%s<%s" % (indent, name)
         if attrs:
-            for key, value in attrs:
-                s.append(' %s=%s' % (key, value))
-        if text:
-            s.append(">%s</%s>\n" % (text, name))
-        elif children_markup:
-            s.append(">\n%s%s</%s>\n" % (children_markup, indent, name))
+            # Different versions put attributes on the same or different
+            # lines, so do this in a separate method to allow overriding it.
+            s += self.format_attrs(attrs, indent)
+
+            if text or children_markup:
+                # Moreover, different versions may or not put a new line
+                # before the closing angle bracket, so we need a method here
+                # too.
+                s += self.format_end_tag_with_attrs(indent)
+            else: # An empty element
+                # Some empty elements are output as "<foo/>" while others as
+                # "<foo>\n</foo>".
+                if name not in self.elems_not_collapsed:
+                    # And different versions close an empty tag differently,
+                    # so abstract it into a separate method as well.
+                    s += self.format_end_empty_tag(indent)
+
+                    # Skip the closing tag addition below.
+                    s += "\n"
+                    return s
+
+                s += self.format_end_tag_with_attrs(indent)
+                s += "\n"
+                s += indent
         else:
-            s.append(" />\n")
-        return "".join(s)
+            if text or children_markup:
+                s += ">"
+            else:
+                s += ">\n"
+                s += indent
+
+        if text:
+            s += text
+        elif children_markup:
+            s += "\n"
+            s += children_markup
+            s += indent
+
+        s += "</%s>\n" % name
+
+        return s
 
     def format_value(self, val):
         # This trick is necessary, because 'val' may be of many types -- in
@@ -296,6 +331,32 @@ class XmlFormatter(object):
         # argument disambiguates these cases, with no noticeable loss of
         # performance.
         return self._format_value(val, type(val))
+
+    def format_attrs(self, attrs, indent):
+        """
+        Returns the list containing formatted attributes.
+
+        Parameters of this method are a subset of format_node() parameters.
+        """
+        s = ''
+        for key, value in attrs:
+            s += ' %s=%s' % (key, value)
+        return s
+
+    def format_end_tag_with_attrs(self, indent):
+        """
+        Returns the string at the end of the opening tag with attributes.
+        """
+        return ">"
+
+    def format_end_empty_tag(self, indent):
+        """
+        Returns the string at the end of an empty tag.
+
+        This method only exists because MSVS 2003 doesn't insert an extra
+        space here while all the other formats do.
+        """
+        return " />"
 
     @memoized
     def _format_value(self, val, valtype):


### PR DESCRIPTION
This is mainly to facilitate comparing bakefile-generated projects with the original, IDE-created, ones.