### PR TITLE
Add MSVS-version-independent vs.solutionfile property

### DIFF
--- a/extras/vim/bkl.vim
+++ b/extras/vim/bkl.vim
@@ -34,6 +34,7 @@ syn keyword	bklGlobalStat	setting
 syn keyword	bklGlobalProp	toolsets
 syn keyword	bklGlobalProp	configurations
 syn match	bklGlobalProp	"\<vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\).generate-solution\ze *=" nextgroup=bklBoolRHS skipwhite
+syn keyword	bklCommonProp	vs.solutionfile
 syn keyword	bklCommonProp	vs2003.solutionfile
 syn keyword	bklCommonProp	vs2005.solutionfile
 syn keyword	bklCommonProp	vs2008.solutionfile

--- a/tests/projects/hello_world/hello_world.bkl
+++ b/tests/projects/hello_world/hello_world.bkl
@@ -1,9 +1,6 @@
 toolsets = gnu gnu-osx gnu-suncc vs2008 vs2010 vs2012 vs2013 vs2015;
 
-vs2012.solutionfile = hello_world_vs2012.sln;
-vs2013.solutionfile = hello_world_vs2013.sln;
-vs2015.solutionfile = hello_world_vs2015.sln;
-vs2008.solutionfile = hello_world_vs2008.sln;
+vs.solutionfile = hello_world_$(toolset).sln;
 
 program hello {
     archs = x86 x86_64;

--- a/tests/projects/hello_world/hello_world.model
+++ b/tests/projects/hello_world/hello_world.model
@@ -1,10 +1,7 @@
 module {
   variables {
     toolsets = [gnu, gnu-osx, gnu-suncc, vs2008, vs2010, vs2012, vs2013, vs2015]
-    vs2012.solutionfile = @top_srcdir/hello_world_vs2012.sln
-    vs2013.solutionfile = @top_srcdir/hello_world_vs2013.sln
-    vs2015.solutionfile = @top_srcdir/hello_world_vs2015.sln
-    vs2008.solutionfile = @top_srcdir/hello_world_vs2008.sln
+    vs.solutionfile = @top_srcdir/hello_world_$(toolset).sln
   }
   targets {
     program hello {


### PR DESCRIPTION
This property can be used to set the location of the solution file using a
single assignment instead of having to do it for each and every MSVS version.

The old version-specific properties still exist, for compatibility and to
allow overriding the solution file location for some specific version.

---

NB: This is going to conflict with the other recent PRs if you decide to merge them, so I'd rather push them myself, from my local branch containing all the changes, if you agree with these changes. I'm also going to implement `vs.projectfile`, `vs.guid` and `vs.generate-solution` if this one is ok.
