### PR TITLE
Handle vs2015 (conditional) externals

### DIFF
--- a/src/bkl/plugins/external.py
+++ b/src/bkl/plugins/external.py
@@ -165,12 +165,14 @@ class VSExternalProject200x(VSExternalProjectBase):
 
 class VSExternalProject201x(VSExternalProjectBase):
     """
-    Wrapper around VS 2010/2012 project files.
+    Wrapper around VS 2010/2012/2013/2015 project files.
     """
     @memoized_property
     def version(self):
         v = self.xml.get("ToolsVersion")
-        if v != "4.0":
+        if v == "14.0":
+            return 14
+        elif v != "4.0":
             raise Error("unrecognized version of Visual Studio project %s: ToolsVersion=\"%s\"" %(
                         self.projectfile, v))
         # TODO-PY26: use "PropertyGroup[@Label='Configuration']"

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -395,6 +395,9 @@ class VS201xToolsetBase(VSToolsetBase):
 
 
     def _get_references(self, target):
+        if not target["deps"]:
+            return None
+
         # In addition to explicit dependencies, add dependencies of static libraries
         # linked into target to the list of references.
         prj = target.project

--- a/src/bkl/plugins/vsbase.py
+++ b/src/bkl/plugins/vsbase.py
@@ -515,7 +515,8 @@ class VSSolutionBase(object):
         included = set(x.name for x in self.all_projects())
         todo = set()
         for prj in self.all_projects():
-            todo.update(prj.dependencies)
+            if prj.dependencies:
+                todo.update(prj.dependencies)
 
         prev_count = 0
         while prev_count != len(included):
@@ -525,7 +526,8 @@ class VSSolutionBase(object):
             for todo_item in sorted(todo):
                 included.add(todo_item)
                 prj = top._get_project_by_id(todo_item)
-                todo_new.update(prj.dependencies)
+                if prj.dependencies:
+                    todo_new.update(prj.dependencies)
                 additional.append(prj)
             todo.update(todo_new)
         return additional


### PR DESCRIPTION
These commits are my attempt so solve the problems with handling the following bakefile:
```
if ( $toolset == vs2015 ) {
    external msvc14_crt_stubs {
        file = msvc14_crt_stubs/msvc14_crt_stubs.vcxproj;
    }
}

template with_some_closed_source_lib {
    if ( $toolset == vs2015 ) {
        deps += msvc14_crt_stubs;
    }
}
```

This seems to work correctly with these changes but I'm not at all sure if they're the right way to do it (well, the first commit seems to be straightforward, it's the second one that I have doubts about). In particular, it would probably be better/safer to just prune the nil dependencies somehow, but I have no idea about how to do it.