### PR TITLE
Use dependencies property even if compile-commands is not set.

### DIFF
--- a/src/bkl/compilers.py
+++ b/src/bkl/compilers.py
@@ -180,7 +180,7 @@ def _make_build_nodes_for_file(toolset, target, srcfile, ft_to, files_map):
         raise Error("don't know how to compile \"%s\" files into \"%s\"" % (ft_from.name, ft_to.name))
 
     node = BuildNode(commands=compiler.commands(toolset, target, src, objname),
-                     inputs=[src],
+                     inputs=[src] + list(srcfile["dependencies"]),
                      outputs=[objname],
                      source_pos=srcfile.source_pos)
     return ([node], [node])

--- a/src/bkl/props.py
+++ b/src/bkl/props.py
@@ -90,10 +90,12 @@ def std_file_props():
              default=[],
              inheritable=False,
              doc="""
-                 List of additional files that the commands that compiles this
-                 source file depend on.
+                 List of additional files that the source file or or its
+                 commands depend on.
 
-                 Only applicable if *compile-commands* is set.
+                 List any files that must be created before the source file is
+                 compiled, such as generated header files. If *compile-commands*
+                 is set, list any other files referenced by the commands.
                  """),
         ]
 

--- a/tests/projects/generated_files/generated_files.bkl
+++ b/tests/projects/generated_files/generated_files.bkl
@@ -32,4 +32,6 @@ program test {
     gensrc2.txt::compile-message = "Running make_gensrc.py to generate %(out).cpp and %(out).h";
     gensrc2.txt::dependencies = make_gensrc.py;
     gensrc2.txt::outputs = @builddir/gensrc2.cpp @builddir/gensrc2.h;
+
+    main.cpp::dependencies = @builddir/gensrc.h @builddir/gensrc2.h;
 }

--- a/tests/projects/generated_files/generated_files.model
+++ b/tests/projects/generated_files/generated_files.model
@@ -7,7 +7,7 @@ module {
     program test {
       includedirs = [@builddir/]
       sources {
-        file @top_srcdir/main.cpp
+        file @top_srcdir/main.cpp	{ dependencies = [@builddir/gensrc.h, @builddir/gensrc2.h] }
         file @top_srcdir/gensrc.txt	{ compile-commands = [python make_gensrc.py --source %(out) %(in)]; compile-message = Running make_gensrc.py to generate %(out); dependencies = [@top_srcdir/make_gensrc.py]; outputs = [@builddir/gensrc.cpp] }
         file @top_srcdir/gensrc2.txt	{ compile-commands = [python make_gensrc.py --both %(out0) %(in)]; compile-message = Running make_gensrc.py to generate %(out).cpp and %(out).h; dependencies = [@top_srcdir/make_gensrc.py]; outputs = [@builddir/gensrc2.cpp, @builddir/gensrc2.h] }
         file @builddir/gensrc.cpp


### PR DESCRIPTION
The dependencies property can be used to build generated headers before compiling the source files that include them. Fixes #46.

This change only affects makefile toolsets.