### PR TITLE
Switch to using parametrized instead of yielding tests

### DIFF
--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -23,26 +23,25 @@
 #
 
 import os, os.path
+import pytest
 from glob import glob
 
 import bkl.parser, bkl.interpreter, bkl.error
 import bkl.dumper
 
-
-def test_full():
-    """
-    Fully tests Bakefile interpreter and compares resulting model with a copy
-    saved in .model file, as well as with all the generated files. Does this
-    for all .bkl files under tests/projects directory that have a model dump
-    present.
-    """
+@pytest.fixture(scope='session')
+def testdir():
     import projects
-    d = os.path.dirname(projects.__file__)
-    for f in glob("%s/*.bkl" % d):
-        yield _test_on_file, d, str(f)
-    for f in glob("%s/*/*.bkl" % d):
-        yield _test_on_file, d, str(f)
+    return os.path.dirname(projects.__file__)
 
+@pytest.fixture(scope='session')
+def project_filenames():
+    """
+    This fixture returns the list of all .bkl files under tests/projects
+    directory.
+    """
+    return [str(f) for f in glob("%s/*.bkl" % testdir())] \
+           + [str(f) for f in glob("%s/*/*.bkl" % testdir())]
 
 class InterpreterForTestSuite(bkl.interpreter.Interpreter):
     def generate(self):
@@ -53,7 +52,12 @@ class InterpreterForTestSuite(bkl.interpreter.Interpreter):
         super(InterpreterForTestSuite, self).generate()
 
 
-def _test_on_file(testdir, project_file):
+@pytest.mark.parametrize('project_file', project_filenames())
+def test_full(testdir, project_file):
+    """
+    Fully tests Bakefile interpreter and compares resulting model with a copy
+    saved in .model file, as well as with all the generated files.
+    """
     assert project_file.startswith(testdir)
 
     model_file = os.path.splitext(project_file)[0] + '.model'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -28,20 +28,25 @@ from glob import glob
 
 import bkl.parser, bkl.error
 
+@pytest.fixture(scope='session')
+def testdir():
+    import test_parsing
+    return os.path.dirname(test_parsing.__file__)
 
-def test_parser():
+@pytest.fixture(scope='session')
+def ast_filenames():
+    """
+    This fixture returns the list of all .bkl files under tests/parser
+    directory that have a matching .ast present.
+    """
+    return [str(f) for f in glob("%s/*/*.ast" % testdir())]
+
+@pytest.mark.parametrize('ast_file', ast_filenames())
+def test_parser(testdir, ast_file):
     """
     Tests Bakefile parser and compares resulting AST with a copy saved
-    in .ast file. Does this for all .bkl files under tests/parser directory
-    that have .ast present.
+    in .ast file.
     """
-    import test_parsing
-    d = os.path.dirname(test_parsing.__file__)
-    for f in glob("%s/*/*.ast" % d):
-        yield _test_parser_on_file, d, str(f)
-
-
-def _test_parser_on_file(testdir, ast_file):
     assert ast_file.startswith(testdir)
 
     input = os.path.splitext(ast_file)[0] + '.bkl'


### PR DESCRIPTION
Pytest 3 deprecates yield tests, resulting in 83 warnings of the form

yield tests are deprecated, and scheduled to be removed in pytest 4.0

being given when running the test suite using it.

Replace them with the parametrized tests, as recommended.

There should be no actual changes to the tests behaviour, the same 91
tests still pass before and after this change.