### PR TITLE
Fix running bkl in non-ASCII path

### DIFF
--- a/src/bkl/expr.py
+++ b/src/bkl/expr.py
@@ -2,7 +2,7 @@
 #
 #  This file is part of Bakefile (http://bakefile.org)
 #
-#  Copyright (C) 2008-2013 Vaclav Slavik
+#  Copyright (C) 2008-2018 Vaclav Slavik
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to
@@ -520,7 +520,7 @@ class PathExpr(Expr):
             base = paths_info.builddir_abs
         else:
             assert False, "unsupported anchor in PathExpr.as_native_path()"
-        comp = (e.as_py() for e in self.components)
+        comp = (e.as_py().encode('utf-8') for e in self.components)
         return os.path.abspath(os.path.join(base, os.path.sep.join(comp)))
 
     def as_native_path_for_output(self, model):
@@ -860,7 +860,7 @@ class PathAnchorsInfo(object):
         """
 
         self.dirsep = dirsep
-        outdir = os.path.dirname(os.path.abspath(outfile))
+        outdir = os.path.dirname(os.path.abspath(outfile.encode('utf-8')))
         self.outdir_abs = outdir
 
         top_srcdir = os.path.abspath(model.project.top_module.srcdir)

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 #  This file is part of Bakefile (http://bakefile.org)
 #
@@ -96,3 +97,28 @@ expected model:
 """ % expected
 
     assert as_text == expected
+
+def test_unicode_filename():
+    """
+    This test checks that filenames relative to a directory containing
+    non-ASCII characters work correctly, see
+    https://github.com/vslavik/bakefile/issues/96
+    """
+    t = bkl.parser.parse("""
+toolsets = gnu;
+program progname {
+    sources { ../relpath.c }
+}
+""", "test.bkl")
+    i = InterpreterForTestSuite()
+
+    import shutil
+    import tempfile
+    cwd = os.getcwd()
+    tmpdir = tempfile.mkdtemp(prefix=u"Üñîçöḍè")
+    os.chdir(tmpdir)
+    try:
+        i.process(t)
+    finally:
+        os.chdir(cwd)
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
os.path.* functions don’t work with non-ASCII paths if a mix of str and
unicode arguments is used, causing bkl to fail with UnicodeDecodeError.

Fix by explicitly converting path components from .bkl files to ANSI
strings. As a consequence, .bkl files are assumed to be in UTF-8.

Fixes #96.