### PR TITLE
Add MSVS 2017 toolset support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@ v1.2.6 (????-??-??)
 New Features
 ------------
 
-- Add MSVS 2015 toolset support.
+- Add MSVS 2015 and 2017 toolsets support.
 
 Bug fixes
 ---------

--- a/extras/vim/bkl.vim
+++ b/extras/vim/bkl.vim
@@ -33,7 +33,7 @@ syn keyword	bklGlobalStat	configuration
 syn keyword	bklGlobalStat	setting
 syn keyword	bklGlobalProp	toolsets
 syn keyword	bklGlobalProp	configurations
-syn match	bklGlobalProp	"\<vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\).generate-solution\ze *=" nextgroup=bklBoolRHS skipwhite
+syn match	bklGlobalProp	"\<vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\).generate-solution\ze *=" nextgroup=bklBoolRHS skipwhite
 syn keyword	bklCommonProp	vs2003.solutionfile
 syn keyword	bklCommonProp	vs2005.solutionfile
 syn keyword	bklCommonProp	vs2008.solutionfile
@@ -41,6 +41,7 @@ syn keyword	bklCommonProp	vs2010.solutionfile
 syn keyword	bklCommonProp	vs2012.solutionfile
 syn keyword	bklCommonProp	vs2013.solutionfile
 syn keyword	bklCommonProp	vs2015.solutionfile
+syn keyword	bklCommonProp	vs2017.solutionfile
 syn keyword	bklCommonProp	gnu.makefile gnu-osx.makefile gnu-suncc.makefile
 
 " Properties common to absolutely all targets.
@@ -52,7 +53,8 @@ syn keyword	bklCommonProp	vs2010.guid vs2010.projectfile contained
 syn keyword	bklCommonProp	vs2012.guid vs2012.projectfile contained
 syn keyword	bklCommonProp	vs2013.guid vs2013.projectfile contained
 syn keyword	bklCommonProp	vs2015.guid vs2015.projectfile contained
-syn match	bklCommonProp	"vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\)\.option\(\.\w\+\)\{1,2}" contained
+syn keyword	bklCommonProp	vs2017.guid vs2017.projectfile contained
+syn match	bklCommonProp	"vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\)\.option\(\.\w\+\)\{1,2}" contained
 
 " Properties that can occur inside action targets only.
 syn keyword	bklActionProp	commands outputs contained

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -60,7 +60,7 @@ class VS2010Project(VSProjectBase):
 
 
 class VS201xToolsetBase(VSToolsetBase):
-    """Base class for VS2010, VS2012, VS2013 and VS2015 toolsets."""
+    """Base class for VS2010, VS2012, VS2013, VS2015 and VS2017 toolsets."""
 
     #: XML formatting class
     XmlFormatter = VS201xXmlFormatter
@@ -702,3 +702,49 @@ class VS2015Toolset(VS201xToolsetBase):
     tools_version = "14.0"
     Solution = VS2015Solution
     Project = VS2015Project
+
+
+class VS2017Solution(VS2010Solution):
+    format_version = "12.00"
+    human_version = "15"
+
+    def write_header(self, file):
+        super(VS2017Solution, self).write_header(file)
+        file.write("VisualStudioVersion = 15.0.27130.2003\n")
+        file.write("MinimumVisualStudioVersion = 10.0.40219.1\n")
+
+
+class VS2017Project(VS2010Project):
+    version = 15
+
+
+class VS2017Toolset(VS201xToolsetBase):
+    """
+    Visual Studio 2017.
+
+
+    Special properties
+    ------------------
+    This toolset supports the same special properties that
+    :ref:`ref_toolset_vs2010`. The only difference is that they are prefixed
+    with ``vs2017.option.`` instead of ``vs2010.option.``, i.e. the nodes are:
+
+      - ``vs2017.option.Globals.*``
+      - ``vs2017.option.Configuration.*``
+      - ``vs2017.option.*`` (this is the unnamed ``PropertyGroup`` with
+        global settings such as ``TargetName``)
+      - ``vs2017.option.ClCompile.*``
+      - ``vs2017.option.ResourceCompile.*``
+      - ``vs2017.option.Link.*``
+      - ``vs2017.option.Lib.*``
+
+    """
+
+    name = "vs2017"
+
+    version = 15
+    proj_versions = [10, 11, 12, 14, 15]
+    platform_toolset = "v141"
+    tools_version = "15.0"
+    Solution = VS2017Solution
+    Project = VS2017Project

--- a/tests/projects/hello_world/hello_world.bkl
+++ b/tests/projects/hello_world/hello_world.bkl
@@ -1,4 +1,4 @@
-toolsets = gnu gnu-osx gnu-suncc vs2003 vs2005 vs2008 vs2010 vs2012 vs2013 vs2015;
+toolsets = gnu gnu-osx gnu-suncc vs2003 vs2005 vs2008 vs2010 vs2012 vs2013 vs2015 vs2017;
 
 vs2003.solutionfile = hello_world_vs2003.sln;
 vs2005.solutionfile = hello_world_vs2005.sln;
@@ -7,6 +7,7 @@ vs2010.solutionfile = hello_world_vs2010.sln;
 vs2012.solutionfile = hello_world_vs2012.sln;
 vs2013.solutionfile = hello_world_vs2013.sln;
 vs2015.solutionfile = hello_world_vs2015.sln;
+vs2017.solutionfile = hello_world_vs2017.sln;
 
 program hello {
     archs = x86 x86_64;
@@ -20,4 +21,5 @@ program hello {
     vs2012.projectfile = hello_vs2012.vcxproj;
     vs2013.projectfile = hello_vs2013.vcxproj;
     vs2015.projectfile = hello_vs2015.vcxproj;
+    vs2017.projectfile = hello_vs2017.vcxproj;
 }

--- a/tests/projects/hello_world/hello_world.model
+++ b/tests/projects/hello_world/hello_world.model
@@ -1,6 +1,6 @@
 module {
   variables {
-    toolsets = [gnu, gnu-osx, gnu-suncc, vs2003, vs2005, vs2008, vs2010, vs2012, vs2013, vs2015]
+    toolsets = [gnu, gnu-osx, gnu-suncc, vs2003, vs2005, vs2008, vs2010, vs2012, vs2013, vs2015, vs2017]
     vs2003.solutionfile = @top_srcdir/hello_world_vs2003.sln
     vs2005.solutionfile = @top_srcdir/hello_world_vs2005.sln
     vs2008.solutionfile = @top_srcdir/hello_world_vs2008.sln
@@ -8,6 +8,7 @@ module {
     vs2012.solutionfile = @top_srcdir/hello_world_vs2012.sln
     vs2013.solutionfile = @top_srcdir/hello_world_vs2013.sln
     vs2015.solutionfile = @top_srcdir/hello_world_vs2015.sln
+    vs2017.solutionfile = @top_srcdir/hello_world_vs2017.sln
   }
   targets {
     program hello {
@@ -20,6 +21,7 @@ module {
       vs2012.projectfile = @top_srcdir/hello_vs2012.vcxproj
       vs2013.projectfile = @top_srcdir/hello_vs2013.vcxproj
       vs2015.projectfile = @top_srcdir/hello_vs2015.vcxproj
+      vs2017.projectfile = @top_srcdir/hello_vs2017.vcxproj
       sources {
         file @top_srcdir/hello.c
       }

--- a/tests/test_model/properties/set_toolsets_bad.model
+++ b/tests/test_model/properties/set_toolsets_bad.model
@@ -1,2 +1,2 @@
 ERROR:
-properties/set_toolsets_bad.bkl:1:11: variable "toolsets" (list of toolsets): expression "nonexistent" is not a valid toolset value: must be one of "gnu", "gnu-osx", "gnu-suncc", "vs2003", "vs2005", "vs2008", "vs2010", "vs2012", "vs2013", "vs2015"
+properties/set_toolsets_bad.bkl:1:11: variable "toolsets" (list of toolsets): expression "nonexistent" is not a valid toolset value: must be one of "gnu", "gnu-osx", "gnu-suncc", "vs2003", "vs2005", "vs2008", "vs2010", "vs2012", "vs2013", "vs2015", "vs2017"


### PR DESCRIPTION
Clone VS2015 classes to create VS2017{Solution,Project,Toolset}.

Similar to 7bb50c8e369b0dc472065249053f72fdc58ab7bd.

---

It's a bit ridiculous to add more or more trivial classes like this, but I'm not sure it's worth refactoring the code to avoid it.