### PR TITLE
Fix the recently added Unicode test under Cygwin

### DIFF
--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -115,7 +115,7 @@ program progname {
     import shutil
     import tempfile
     cwd = os.getcwd()
-    tmpdir = tempfile.mkdtemp(prefix=u"Üñîçöḍè")
+    tmpdir = tempfile.mkdtemp(prefix=u"Üñîçöḍè".encode('utf-8'))
     os.chdir(tmpdir)
     try:
         i.process(t)


### PR DESCRIPTION
Explicitly convert Unicode prefix to UTF-8.

---

Without this change, the test fails under Cygwin with

    UnicodeEncodeError: 'ascii' codec can't encode characters in position 16-22: ordinal not in range(128)

inside `mkdtemp()` itself (in `/usr/lib/python2.7/tempfile.py`). Interestingly enough, it passes under native Windows Python, but this is probably because it doesn't use the sample implementation of `mkdtemp()`.

However, with native Python I still get a warning:
```
tests/test_full.py::test_unicode_filename
  w:\dev\lang\python\2.7.11\lib\ntpath.py:533: UnicodeWarning: Unicode unequal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
    if e1.lower() != e2.lower():
```
that I have no idea how to avoid (and it happens with and without this change).

Finally, just to unburden of all my problems at once, I also get the completely mysterious
```
/usr/lib/python2.7/site-packages/py-1.4.22-py2.7.egg/py/_path/local.py:620: in pyimport
    __import__(modname)
/usr/lib/python2.7/site-packages/pytest-2.6.0-py2.7.egg/_pytest/assertion/rewrite.py:134: in find_module
    co = _read_pyc(fn_pypath, pyc)
/usr/lib/python2.7/site-packages/pytest-2.6.0-py2.7.egg/_pytest/assertion/rewrite.py:311: in _read_pyc
    co = marshal.load(fp)
E   ValueError: bad marshal data (unknown type code)
```
that I just chose to ignore because this is clearly some Cygwin weirdness, as the test passes just fine with the native Python (but if this tells you something, please let me know).