### PR TITLE
Ensure that dependencies are not duplicated

### DIFF
--- a/src/bkl/api.py
+++ b/src/bkl/api.py
@@ -232,6 +232,13 @@ class Property(object):
        derived from some other value and exist as a convenience. An example
        of read-only property is the ``id`` property on targets.
 
+    .. attribute:: idempotent
+
+       If a list property is idempotent, appending an element already existing
+       in the list does nothing, instead of adding a second copy of it. This
+       is useful for the list of the target dependencies, for example, as it's
+       not useful to depend on something more than once.
+
     .. attribute:: scopes
 
        Optional scope of the property, as list of strings. Each item may be one
@@ -284,11 +291,12 @@ class Property(object):
     SCOPE_SETTING = "setting"
 
     def __init__(self, name, type, default=None, readonly=False,
-                 inheritable=False, doc=None):
+                 idempotent=False, inheritable=False, doc=None):
         self.name = name
         self.type = type
         self.default = default
         self.readonly = readonly
+        self.idempotent = idempotent
         self.inheritable = inheritable
         self.scopes = None
         self.toolsets = None

--- a/src/bkl/model.py
+++ b/src/bkl/model.py
@@ -60,6 +60,11 @@ class Variable(object):
        Indicates if the variable is read-only. Read-only variables can only
        be assigned once and cannot be modified afterwards.
 
+    .. attribute:: idempotent
+
+       Idempotent list variables are not changed by appending an item already
+       existing in the list to them.
+
     .. attribute:: is_property
 
        Indicates if the variable corresponds to a property.
@@ -69,13 +74,15 @@ class Variable(object):
        Indicates if the value was set explicitly by the user.
        Normally true, only false for properties' default values.
     """
-    def __init__(self, name, value, type=None, readonly=False, source_pos=None):
+    def __init__(self, name, value, type=None, readonly=False,
+                 idempotent=False, source_pos=None):
         self.name = name
         if type is None:
             type = vartypes.TheAnyType
         self.type = type
         self.value = value
         self.readonly = readonly
+        self.idempotent = idempotent
         self.is_property = False
         self.is_explicitly_set = True
         self.pos = source_pos
@@ -90,7 +97,8 @@ class Variable(object):
         v = Variable(name=prop.name,
                      value=value,
                      type=prop.type,
-                     readonly=prop.readonly)
+                     readonly=prop.readonly,
+                     idempotent=prop.idempotent)
         v.is_property = True
         return v
 

--- a/src/bkl/props.py
+++ b/src/bkl/props.py
@@ -113,6 +113,7 @@ def std_target_props():
         Property("deps",
                  type=ListType(IdType()),
                  default=[],
+                 idempotent=True,
                  inheritable=False,
                  doc="""
                      Dependencies of the target (list of IDs).

--- a/tests/test_generation/.gitignore
+++ b/tests/test_generation/.gitignore
@@ -1,0 +1,6 @@
+*.vcproj
+*.vcxproj
+*.vcxproj.filters
+GNUmakefile
+Makefile.osx
+Makefile.suncc

--- a/tests/test_generation/dup_deps/dup_deps.bkl
+++ b/tests/test_generation/dup_deps/dup_deps.bkl
@@ -1,0 +1,16 @@
+toolsets = vs2010;
+
+vs2010.solutionfile = dup_deps.sln;
+
+library libA {
+    sources { a.c }
+}
+
+template usesA {
+    deps = libA;
+}
+
+program dup_deps : usesA {
+    deps += libA;
+    sources { dup_deps.c }
+}

--- a/tests/test_generation/dup_deps/test_dup_deps.py
+++ b/tests/test_generation/dup_deps/test_dup_deps.py
@@ -1,0 +1,51 @@
+#  This file is part of Bakefile (http://bakefile.org)
+#
+#  Copyright (C) 2018 Vadim Zeitlin
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to
+#  deal in the Software without restriction, including without limitation the
+#  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+#  sell copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+#  IN THE SOFTWARE.
+#
+
+import os, os.path
+import pytest
+import bkl.parser, bkl.interpreter, bkl.error
+from indir import in_directory
+
+def test_dup_deps():
+    with in_directory(os.path.dirname(__file__)):
+        t = bkl.parser.parse_file('dup_deps.bkl')
+        i = bkl.interpreter.Interpreter()
+        i.process(t)
+
+        with open('dup_deps.sln', "rt") as sln:
+            # Find the number of dependencies for the project (we rely on
+            # there being only a single dependencies section).
+            num_deps = 0
+            inside_deps = False
+            for line in sln.readlines():
+                if inside_deps:
+                    if 'EndProjectSection' in line:
+                        break
+
+                    num_deps += 1
+                elif 'ProjectSection(ProjectDependencies)' in line:
+                    inside_deps = True
+
+            # The dependency should only be counted once, even if it's
+            # mentioned twice in the input bakefile.
+            assert num_deps == 1


### PR DESCRIPTION
We had problems with MSVS rewriting the .sln files all the time because it removed duplicate dependencies from them and while I did fix the issue for now by ensuring that no dependencies are duplicated in the bakefiles, it wasn't simple to track all of them down, so I'd like to modify bkl itself to just ignore the duplicates if this happens.

I'm not really sure if it's the best thing to do, it might be better to give an error (or a warning?) in this case instead. But I think that there could be situations in which such duplicates could be not trivial to avoid (even though I can't give any realistic examples right now), so for now I did just this.

I'm also not sure if what I did is the best way of achieving the goal, initially I thought to add a `SetType`, but got scared by having to modify all this machinery and finally did the smallest possible change I could think of. Finally, I'm not sure about the "idempotent" name neither, but, again, I just couldn't find anything better -- suggestions would be welcome, of course. TIA!

Note: this depends on #103, but I'm submitting just these commits for review for clarity.