### PR TITLE
Generate configurations in alphabetical order in MSVS solutions

### DIFF
--- a/src/bkl/plugins/vsbase.py
+++ b/src/bkl/plugins/vsbase.py
@@ -574,9 +574,13 @@ class VSSolutionBase(object):
         if not included_projects:
             return # don't write empty solution files
 
-        configurations = OrderedSet()
+        configurations_set = set()
         for prj in all_own_projects:
-            configurations.update(prj.configurations)
+            configurations_set.update(prj.configurations)
+
+        # MSVS own projects always list configurations in alphabetical order,
+        # so do the same thing as it does.
+        configurations = sorted(configurations_set, key=lambda c: c.name.lower())
 
         platforms = OrderedSet()
         for prj in all_own_projects:


### PR DESCRIPTION
This avoids spurious changes when solutions files are saved from MSVS as
it reorders the configurations in alphabetical order, even if they were
not ordered initially when saving.