### PR TITLE
Allow specifying configurations/platforms for externals

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,7 @@ New Features
 ------------
 
 - Add MSVS 2015 and 2017 toolsets support.
+- Allow specifying configurations/platforms for external projects.
 
 Bug fixes
 ---------

--- a/extras/vim/bkl.vim
+++ b/extras/vim/bkl.vim
@@ -60,7 +60,7 @@ syn match	bklCommonProp	"vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\)\.o
 syn keyword	bklActionProp	commands outputs contained
 
 " Properties that can occur inside external targets only.
-syn keyword	bklExtProp	file contained
+syn keyword	bklExtProp	file archs configurations contained
 
 " Properties that can only occur in the targets building something i.e.
 " program/lib/dll ones.

--- a/extras/vim/bkl.vim
+++ b/extras/vim/bkl.vim
@@ -59,6 +59,9 @@ syn match	bklCommonProp	"vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\)\.o
 " Properties that can occur inside action targets only.
 syn keyword	bklActionProp	commands outputs contained
 
+" Properties that can occur inside external targets only.
+syn keyword	bklExtProp	file contained
+
 " Properties that can only occur in the targets building something i.e.
 " program/lib/dll ones.
 syn keyword	bklBuildProp	archs basename configurations contained
@@ -102,6 +105,7 @@ syn cluster	bklAnyBlock	contains=bklBlock,bklComment,bklCommentL,bklCommonProp,b
 
 syn region	bklBuildBlock	matchgroup=Normal start="\%\(\(program\|library\|shared-library\|loadable-module\|template\)\_s\+\k\+\%\(\_s*:\_s*\k\+\%\(\_s*,\_s*\k\+\)*\)\?\_s*\)\@<={" end="}" contains=@bklAnyBlock,bklBuildProp
 syn region	bklActionBlock	matchgroup=Normal start="\%\(action\_s\+\k\+\_s*\)\@<={" end="}" contains=@bklAnyBlock,bklActionProp
+syn region	bklExtBlock	matchgroup=Normal start="\%\(external\_s\+\k\+\_s*\)\@<={" end="}" contains=@bklAnyBlock,bklExtProp
 syn region	bklSettingBlock	matchgroup=Normal start="\%\(setting\_s\+\k\+\_s*\)\@<={" end="}" contains=bklSettingProp
 
 
@@ -114,6 +118,7 @@ hi def link bklCommentBoundary	bklComment
 hi def link bklCommentL		bklComment
 hi def link bklCommonProp	bklGlobalProp
 hi def link bklError		Error
+hi def link bklExtProp		bklCommonProp
 hi def link bklFilename		bklString
 hi def link bklGlobalProp	Keyword
 hi def link bklGlobalStat	Statement


### PR DESCRIPTION
I'd appreciate if you could please have a look at this one: I'm almost certain that the approach here is correct, i.e. we need to provide a way to define the configs/platforms explicitly as we just can't reliably auto-detect them in 100% of cases, but I'm also pretty sure that my implementation is suboptimal.

Notably I'd prefer to use just `configurations` for the property, but I couldn't make this work: there is a standard property with this name and I don't know how to check if the property value is really defined in the `external` or is inherited. Is this (easily) possible? If not, do you see some other, better way to handle this?

And if we keep `vs_configurations` for this property, should we use `vs_platforms` for the other one for consistency?

TIA!