### PR TITLE
Allow specifying extra property files for generated MSVS projects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ New Features
 
 - Add MSVS 2015 and 2017 toolsets support.
 - Allow specifying configurations/platforms for external projects.
+- Support including user-defined property sheets in MSVS 201x toolsets.
 
 Bug fixes
 ---------

--- a/extras/vim/bkl.vim
+++ b/extras/vim/bkl.vim
@@ -54,6 +54,7 @@ syn keyword	bklCommonProp	vs2012.guid vs2012.projectfile contained
 syn keyword	bklCommonProp	vs2013.guid vs2013.projectfile contained
 syn keyword	bklCommonProp	vs2015.guid vs2015.projectfile contained
 syn keyword	bklCommonProp	vs2017.guid vs2017.projectfile contained
+syn keyword	bklCommonProp	vs.property-sheets contained
 syn match	bklCommonProp	"vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\)\.option\(\.\w\+\)\{1,2}" contained
 
 " Properties that can occur inside action targets only.

--- a/src/bkl/plugins/vs200x.py
+++ b/src/bkl/plugins/vs200x.py
@@ -176,6 +176,11 @@ class VS200xToolsetBase(VSToolsetBase):
     #: Whether Detect64BitPortabilityProblems is supported
     detect_64bit_problems = True
 
+    @classmethod
+    def properties_target(cls):
+        for p in cls.properties_target_vsbase():
+            yield p
+
     def gen_for_target(self, target, project):
         root = Node("VisualStudioProject")
         root["ProjectType"] = "Visual C++"

--- a/src/bkl/plugins/vs200x.py
+++ b/src/bkl/plugins/vs200x.py
@@ -178,8 +178,7 @@ class VS200xToolsetBase(VSToolsetBase):
 
     @classmethod
     def properties_target(cls):
-        for p in cls.properties_target_vsbase():
-            yield p
+        return cls.properties_target_vsbase()
 
     def gen_for_target(self, target, project):
         root = Node("VisualStudioProject")

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -75,24 +75,24 @@ class VS201xToolsetBase(VSToolsetBase):
     #: ToolsVersion property
     tools_version = "4.0"
 
-    property_sheets_property_defined = False
+    properties_target_vs = [
+            Property("vs.property-sheets",
+                     type=ListType(PathType()),
+                     default=bkl.expr.NullExpr(),
+                     inheritable=False,
+                     doc="""
+                         May contain paths to one or more property sheets files
+                         that will be imported from the generated project if they
+                         exist.
+                         """)
+        ]
 
     @classmethod
     def properties_target(cls):
         for p in cls.properties_target_vsbase():
             yield p
-
-        if not VS201xToolsetBase.property_sheets_property_defined:
-            VS201xToolsetBase.property_sheets_property_defined = True
-            yield Property("vs.property-sheets",
-                    type=ListType(PathType()),
-                    default=bkl.expr.NullExpr(),
-                    inheritable=False,
-                    doc="""
-                        May contain paths to one or more property sheets files
-                        that will be imported from the generated project if they
-                        exist.
-                        """)
+        for p in cls.properties_target_vs:
+            yield p
 
     def gen_for_target(self, target, project):
         rc_files = []

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -30,6 +30,7 @@ from bkl.io import OutputFile, EOL_WINDOWS
 
 from bkl.plugins.vsbase import *
 from bkl.expr import concat, format_string
+from bkl.vartypes import ListType, PathType
 
 
 class VS201xXmlFormatter(XmlFormatter):
@@ -73,6 +74,25 @@ class VS201xToolsetBase(VSToolsetBase):
 
     #: ToolsVersion property
     tools_version = "4.0"
+
+    property_sheets_property_defined = False
+
+    @classmethod
+    def properties_target(cls):
+        for p in cls.properties_target_vsbase():
+            yield p
+
+        if not VS201xToolsetBase.property_sheets_property_defined:
+            VS201xToolsetBase.property_sheets_property_defined = True
+            yield Property("vs.property-sheets",
+                    type=ListType(PathType()),
+                    default=bkl.expr.NullExpr(),
+                    inheritable=False,
+                    doc="""
+                        May contain paths to one or more property sheets files
+                        that will be imported from the generated project if they
+                        exist.
+                        """)
 
     def gen_for_target(self, target, project):
         rc_files = []
@@ -144,6 +164,17 @@ class VS201xToolsetBase(VSToolsetBase):
                   Project="$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props",
                   Condition="exists('$(UserRootDir)\\Microsoft.Cpp.$(Platform).user.props')",
                   Label="LocalAppDataPlatform")
+
+            for property_sheet in cfg["vs.property-sheets"]:
+                # For now, always add exists() condition unconditionally as
+                # it's often useful to have it, but we don't provide any way
+                # to request it explicitly and not having it would be more
+                # problematic than using it unnecessarily (which is not really
+                # a problem in practice).
+                n.add("Import",
+                      Project=property_sheet,
+                      Condition=concat("exists('", property_sheet, "')"))
+
             root.add(n)
 
         root.add("PropertyGroup", Label="UserMacros")

--- a/src/bkl/plugins/vsbase.py
+++ b/src/bkl/plugins/vsbase.py
@@ -720,7 +720,7 @@ class VSToolsetBase(Toolset):
     loadable_module_extension = "dll"
 
     @classmethod
-    def properties_target(cls):
+    def properties_target_vsbase(cls):
         yield Property("%s.projectfile" % cls.name,
                        type=PathType(),
                        default=update_wrapper(partial(_project_name_from_solution, cls), _project_name_from_solution),


### PR DESCRIPTION
Add support for using "vs201x.option.PropertySheets.Import" to specify
the extra property sheets to include in the generated MSVS projects.

---

This is not finished yet, but it works for me in my tests, so if you don't have any violent objections to this, I'm going to improve it (if you tell me how :-), document it, maybe add some tests (but I have no idea how right now) and merge it. Concerning the improvements, here is the list of things that I *know* or, at least, strongly suspect that I'm doing wrong:

1. Can I obtain the relative path to the `.props` file in some simpler/better way than by creating a `PathExpr` from a single "component" and then using `formatter.expr_formatter`? Everything seems very clumsy here, but it was the only way I could find to generate the correct paths on output. In particular, I completely failed to use either `as_native_path()` or `as_native_path_for_output()`.
1. Speaking of clumsy, there must be some way of iterating over `value` not involving `isinstance(ListExpr)` check, but, again, this was the only thing I found that allowed me to handle both `Import = hello.props` and `Import = hello.props goodbye.props` (or `Import += goodbye.props`) and I do need this.
1. Of course, the entire idea of using `vs201x.option.PropertySheets.Import` is quite suspicious too as it's not handled verbatim, as all the other options in this family. But, again, I couldn't think of anything better and it's not a big stretch to use this for something MSVS-specific, is it?

Of course, there could be more things that I don't even know about but that I'm still doing wrong too, please do let me know about them.

Also, if you have any advice about how to add a unit test for this, it'd be welcome: I'd like to check for the presence of the expected `<Import Project="..." />` in the generated file, but there doesn't seem to be any support for this in the test suite, is there?

TIA!