### PR TITLE
Add "inputs" property for action targets

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,7 @@ New Features
 - Add MSVS 2015 and 2017 toolsets support.
 - Allow specifying configurations/platforms for external projects.
 - Support including user-defined property sheets in MSVS 201x toolsets.
+- Add "inputs" property for action targets.
 
 Bug fixes
 ---------

--- a/extras/vim/bkl.vim
+++ b/extras/vim/bkl.vim
@@ -58,7 +58,7 @@ syn keyword	bklCommonProp	vs.property-sheets contained
 syn match	bklCommonProp	"vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\)\.option\(\.\w\+\)\{1,2}" contained
 
 " Properties that can occur inside action targets only.
-syn keyword	bklActionProp	commands outputs contained
+syn keyword	bklActionProp	commands inputs outputs contained
 
 " Properties that can occur inside external targets only.
 syn keyword	bklExtProp	file archs configurations contained

--- a/src/bkl/plugins/action.py
+++ b/src/bkl/plugins/action.py
@@ -43,6 +43,12 @@ class ActionTargetType(TargetType):
     ``pre-build-commands`` and ``post-build-commands`` properties for another
     alternative that is supported by Visual Studio projects.
 
+    The optional ``inputs`` property may be used to specify the list of file
+    paths that the makefile target generated for this action should depend on.
+    Notice that if the action depends on another target defined in the
+    bakefile, this should be specified in ``deps``, as for any other kind of
+    target and not in ``inputs``.
+
     If the optional ``outputs`` property is specified, the action is supposed
     to generate the files listed in this property. This means that other
     targets depending on this action will depend on these files in the
@@ -69,6 +75,12 @@ class ActionTargetType(TargetType):
                  inheritable=False,
                  doc="List of commands to run."),
 
+            Property("inputs",
+                 type=ListType(PathType()),
+                 default=expr.NullExpr(),
+                 inheritable=False,
+                 doc="Extra input files this action depends on, if any."),
+
             Property("outputs",
                  type=ListType(PathType()),
                  default=expr.NullExpr(),
@@ -82,6 +94,7 @@ class ActionTargetType(TargetType):
         cmds = add_prefix("@", cmds_var)
         node = BuildNode(commands=list(cmds),
                          name=target["id"],
+                         inputs=target["inputs"],
                          outputs=target["outputs"],
                          source_pos=cmds_var.pos)
         return BuildSubgraph(node)

--- a/tests/projects/action/action.bkl
+++ b/tests/projects/action/action.bkl
@@ -8,6 +8,7 @@ action hello {
 
 action build-external-lib {
     commands = "make -C external-dir";
+    inputs = external-dir/Makefile;
     outputs = external-dir/libexternal.so;
 }
 

--- a/tests/projects/action/action.model
+++ b/tests/projects/action/action.model
@@ -8,6 +8,7 @@ module {
     }
     action build-external-lib {
       commands = [make -C external-dir]
+      inputs = [@top_srcdir/external-dir/Makefile]
       outputs = [@top_srcdir/external-dir/libexternal.so]
     }
     program main {


### PR DESCRIPTION
This can be useful as action commands often use files that are not
generated by bakefile and need to be rerun when these files change.

---

For once I don't actually have any questions, as this seems straightforward enough, but I'm always open to learning what did I do wrong this time, so please have a look at this small PR if you can. TIA!