### PR TITLE
makefile_defs_mingw.bkl: use response files to avoid excessively long shell statements

### DIFF
--- a/rules/makefile_defs_mingw.bkl
+++ b/rules/makefile_defs_mingw.bkl
@@ -66,19 +66,22 @@
     </template>
     <template id="__commands_templ">
         <set var="__LINK_EXE_CMD" eval="0">
-            $(DOLLAR)(file &gt;$@.rsp,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)))
+            $(DOLLAR)(foreach f,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)),$(DOLLAR)(shell echo $(DOLLAR)f &gt;&gt; $@.rsp.tmp))
+            @move /y $@.rsp.tmp $@.rsp
             $(__linker) -o $@ @$@.rsp $(__ldflags_all) $(__ldlibs)
             @$(RM) $@.rsp
         </set>
         <set var="__LINK_LIB_CMD" eval="0">
+            $(DOLLAR)(foreach f,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)),$(DOLLAR)(shell echo $(DOLLAR)f &gt;&gt; $@.rsp.tmp))
+            @move /y $@.rsp.tmp $@.rsp
             if exist $@ del $@
-            $(DOLLAR)(file &gt;$@.rsp,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)))
             $(AR) $(AROPTIONS) $@ @$@.rsp
             @$(RM) $@.rsp
             $(RANLIB) $@
         </set>
         <set var="__LINK_DLL_CMD" eval="0">
-            $(DOLLAR)(file &gt;$@.rsp,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)))
+            $(DOLLAR)(foreach f,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)),$(DOLLAR)(shell echo $(DOLLAR)f &gt;&gt; $@.rsp.tmp))
+            @move /y $@.rsp.tmp $@.rsp
             $(__dll_linker) $@ @$@.rsp $(__ldflags_all) $(__ldlibs)
             @$(RM) $@.rsp
         </set>

--- a/rules/makefile_defs_mingw.bkl
+++ b/rules/makefile_defs_mingw.bkl
@@ -27,10 +27,10 @@
 
 -->
 <makefile>
-    
+
     <include file="win32.bkl"/>
     <include file="makefile_defs_gnu.bkl"/>
-    
+
     <set var="AR">ar</set>
     <set var="RANLIB">ranlib</set>
     <set var="WINDRES">windres --use-temp-file</set>
@@ -41,16 +41,16 @@
     <set var="DLLIMPEXT">.a</set>
     <set var="DLLPREFIX"></set>
     <set var="PIC_CFLAGS"></set>
-    
+
     <set var="__LINKER_CC" eval="0">$(CC)</set>
     <set var="__LINKER_CXX" eval="0">$(CXX)</set>
-    
+
     <set var="__FLAG_MULTI_THREADING_LD">-mthreads</set>
     <set var="__FLAG_MULTI_THREADING_CPP">-mthreads</set>
 
     <set var="__FLAG_EXE_CONSOLE"></set>
     <set var="__FLAG_EXE_GUI">-Wl,--subsystem,windows -mwindows</set>
-    
+
     <!-- dependency tracking: -->
     <set var="CPPDEPS" make_var="1">-MT$(DOLLAR)@ -MF$(DOLLAR)@.d -MD -MP</set>
 

--- a/rules/makefile_defs_mingw.bkl
+++ b/rules/makefile_defs_mingw.bkl
@@ -66,13 +66,13 @@
     </template>
     <template id="__commands_templ">
         <set var="__LINK_EXE_CMD" eval="0">
-            $(DOLLAR)(foreach f,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)),$(DOLLAR)(shell echo $(DOLLAR)f &gt;&gt; $@.rsp.tmp))
+            $(DOLLAR)(foreach f,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)),$(DOLLAR)(shell echo $(DOLLAR)f &gt;&gt; $(DOLLAR)(subst &#92;,&#47;,$@).rsp.tmp))
             @move /y $@.rsp.tmp $@.rsp
             $(__linker) -o $@ @$@.rsp $(__ldflags_all) $(__ldlibs)
             @$(RM) $@.rsp
         </set>
         <set var="__LINK_LIB_CMD" eval="0">
-            $(DOLLAR)(foreach f,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)),$(DOLLAR)(shell echo $(DOLLAR)f &gt;&gt; $@.rsp.tmp))
+            $(DOLLAR)(foreach f,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)),$(DOLLAR)(shell echo $(DOLLAR)f &gt;&gt; $(DOLLAR)(subst &#92;,&#47;,$@).rsp.tmp))
             @move /y $@.rsp.tmp $@.rsp
             if exist $@ del $@
             $(AR) $(AROPTIONS) $@ @$@.rsp
@@ -80,7 +80,7 @@
             $(RANLIB) $@
         </set>
         <set var="__LINK_DLL_CMD" eval="0">
-            $(DOLLAR)(foreach f,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)),$(DOLLAR)(shell echo $(DOLLAR)f &gt;&gt; $@.rsp.tmp))
+            $(DOLLAR)(foreach f,$(DOLLAR)(subst &#92;,&#47;,$(__objects_var)),$(DOLLAR)(shell echo $(DOLLAR)f &gt;&gt; $(DOLLAR)(subst &#92;,&#47;,$@).rsp.tmp))
             @move /y $@.rsp.tmp $@.rsp
             $(__dll_linker) $@ @$@.rsp $(__ldflags_all) $(__ldlibs)
             @$(RM) $@.rsp


### PR DESCRIPTION
Fixes #108 

* tested with the stress case `MONOLITHIC=1`  against `wxWidget 3.1.2`
* currently the response files are removed at recipe end.  It could be of value to leave them in the target folder as information about the content of each of the targets
* commits across the branches `response-files` and `response-files-2` could be squashed, since no need to archive intermediate development states
* [trac ticket](https://trac.wxwidgets.org/ticket/18135) could be closed
* please edit as you may find appropriate

HTH.