### PR TITLE
Use default include directories in MSVS projects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,7 @@ Bug fixes
 
 - Changing variable appearing in "source" statement of a base template
   from the derived target now works as expected.
+- Respect default value of "AdditionalIncludeDirectories" in MSVS projects.
 - Simplify paths involving $(builddir) in the "gnu" toolset output.
 - Generate correct warning options for "suncc" backend.
 - Fix linking shared libraries with Sun toolset, use "-lc" explicitly.

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -219,7 +219,7 @@ class VS201xToolsetBase(VSToolsetBase):
             n_cl.add("PreprocessorDefinitions", list(cfg["defines"]) + std_defs)
             n_cl.add("MultiProcessorCompilation", True)
             n_cl.add("MinimalRebuild", False)
-            n_cl.add("AdditionalIncludeDirectories", cfg["includedirs"])
+            n_cl.add_with_default("AdditionalIncludeDirectories", cfg["includedirs"])
 
             crt = "MultiThreaded"
             if cfg.is_debug:
@@ -244,7 +244,7 @@ class VS201xToolsetBase(VSToolsetBase):
 
             if rc_files:
                 n_res = Node("ResourceCompile")
-                n_res.add("AdditionalIncludeDirectories", cfg["includedirs"])
+                n_res.add_with_default("AdditionalIncludeDirectories", cfg["includedirs"])
                 std_defs = []
                 if cfg["win32-unicode"]:
                     std_defs.append("_UNICODE")
@@ -260,7 +260,7 @@ class VS201xToolsetBase(VSToolsetBase):
 
             if idl_files:
                 n_idl = Node("Midl")
-                n_idl.add("AdditionalIncludeDirectories", cfg["includedirs"])
+                n_idl.add_with_default("AdditionalIncludeDirectories", cfg["includedirs"])
                 self._add_extra_options_to_node(cfg, n_idl)
                 n.add(n_idl)
 

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -215,8 +215,7 @@ class VS201xToolsetBase(VSToolsetBase):
                 n_cl.add("FunctionLevelLinking", True)
                 n_cl.add("IntrinsicFunctions", True)
             std_defs = self.get_std_defines(target, cfg)
-            std_defs.append("%(PreprocessorDefinitions)")
-            n_cl.add("PreprocessorDefinitions", list(cfg["defines"]) + std_defs)
+            n_cl.add_with_default("PreprocessorDefinitions", list(cfg["defines"]) + std_defs)
             n_cl.add("MultiProcessorCompilation", True)
             n_cl.add("MinimalRebuild", False)
             n_cl.add_with_default("AdditionalIncludeDirectories", cfg["includedirs"])
@@ -235,9 +234,7 @@ class VS201xToolsetBase(VSToolsetBase):
             all_cflags = VSList(" ", cfg["compiler-options"],
                                      cfg["c-compiler-options"],
                                      cfg["cxx-compiler-options"])
-            if all_cflags:
-                all_cflags.append("%(AdditionalOptions)")
-                n_cl.add("AdditionalOptions", all_cflags)
+            n_cl.add_with_default("AdditionalOptions", all_cflags)
 
             self._add_extra_options_to_node(cfg, n_cl)
             n.add(n_cl)
@@ -253,8 +250,7 @@ class VS201xToolsetBase(VSToolsetBase):
                 # the explanation of why do we do this even though the native
                 # projects don't define _DEBUG/NDEBUG for the RC files.
                 std_defs.append("_DEBUG" if cfg.is_debug else "NDEBUG")
-                std_defs.append("%(PreprocessorDefinitions)")
-                n_res.add("PreprocessorDefinitions", list(cfg["defines"]) + std_defs)
+                n_res.add_with_default("PreprocessorDefinitions", list(cfg["defines"]) + std_defs)
                 self._add_extra_options_to_node(cfg, n_res)
                 n.add(n_res)
 
@@ -275,24 +271,19 @@ class VS201xToolsetBase(VSToolsetBase):
                 n_link.add("OptimizeReferences", True)
             if not is_library(target):
                 libdirs = VSList(";", target.type.get_libdirs(cfg))
-                if libdirs:
-                    libdirs.append("%(AdditionalLibraryDirectories)")
-                    n_link.add("AdditionalLibraryDirectories", libdirs)
+                n_link.add_with_default("AdditionalLibraryDirectories", libdirs)
                 ldflags = VSList(" ", target.type.get_link_options(cfg))
-                if ldflags:
-                    ldflags.append("%(AdditionalOptions)")
-                    n_link.add("AdditionalOptions", ldflags)
+                n_link.add_with_default("AdditionalOptions", ldflags)
                 libs = target.type.get_ldlibs(cfg)
                 if libs:
                     addlibs = VSList(";", ("%s.lib" % x.as_py() for x in libs if x))
-                    addlibs.append("%(AdditionalDependencies)")
                     if is_library(target):
                         n_lib = Node("Lib")
                         self._add_extra_options_to_node(cfg, n_lib)
                         n.add(n_lib)
-                        n_lib.add("AdditionalDependencies", addlibs)
+                        n_lib.add_with_default("AdditionalDependencies", addlibs)
                     else:
-                        n_link.add("AdditionalDependencies", addlibs)
+                        n_link.add_with_default("AdditionalDependencies", addlibs)
             self._add_extra_options_to_node(cfg, n_link)
             n.add(n_link)
 

--- a/src/bkl/plugins/vsbase.py
+++ b/src/bkl/plugins/vsbase.py
@@ -137,6 +137,27 @@ class Node(object):
                     return
         assert 0, "add() is confused: what are you trying to do?"
 
+    def add_with_default(self, name, value):
+        """
+        Add an element with the given value and the default element value.
+
+        This produces output of the form "<Foo>our-value-of-foo;%(Foo)</Foo>"
+        in the generated project file, which is desirable as it preserves any
+        changes to this property in the previously included property sheets.
+
+        Additionally, if the value is empty, this method doesn't do anything
+        at all as using empty value followed by the current value of the
+        property is equivalent to doing nothing in any case.
+        """
+        if not value:
+            # If there is no value at all, there is no need to add anything.
+            return
+
+        value_with_def = list(value)
+        value_with_def.append('%%(%s)' % name)
+
+        self.children.append((name, value_with_def))
+
     def add_or_replace(self, name, value):
         """
         Add a child to this node, replacing the existing child with the same

--- a/src/bkl/plugins/vsbase.py
+++ b/src/bkl/plugins/vsbase.py
@@ -153,7 +153,10 @@ class Node(object):
             # If there is no value at all, there is no need to add anything.
             return
 
-        value_with_def = list(value)
+        if isinstance(value, VSList):
+            value_with_def = VSList(value.list_sep, value.items)
+        else:
+            value_with_def = list(value)
         value_with_def.append('%%(%s)' % name)
 
         self.children.append((name, value_with_def))


### PR DESCRIPTION
The actually important commit here is the first one, as it prevented changes done to `AdditionalIncludeDirectories` in the property sheets from being taken into account, but I think the second one is nice to have too -- please let me know if you disagree. TIA!