### PR TITLE
Fix tests with pytest 4 by not calling fixtures directly

### DIFF
--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -30,16 +30,14 @@ import bkl.parser, bkl.interpreter, bkl.error
 import bkl.dumper
 from indir import in_directory
 
-@pytest.fixture(scope='session')
 def testdirs():
     import test_parsing, test_model
     return [os.path.dirname(test_parsing.__file__),
             os.path.dirname(test_model.__file__)]
 
-@pytest.fixture(scope='session')
 def model_filenames():
     """
-    This fixture returns the list of pairs consisting of the directory name
+    This function returns the list of pairs consisting of the directory name
     and file name of all .bkl files under tests/parsing and test/model
     directories that have a model dump present.
     """

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -32,19 +32,21 @@ import bkl.dumper
 
 from indir import in_directory
 
-@pytest.fixture(scope='session')
-def testdir():
+def do_get_testdir():
     import projects
     return os.path.dirname(projects.__file__)
 
 @pytest.fixture(scope='session')
+def testdir():
+    return do_get_testdir()
+
 def project_filenames():
     """
-    This fixture returns the list of all .bkl files under tests/projects
+    This function returns the list of all .bkl files under tests/projects
     directory.
     """
-    return ([str(f) for f in glob("%s/*.bkl" % testdir())] +
-            [str(f) for f in glob("%s/*/*.bkl" % testdir())])
+    return ([str(f) for f in glob("%s/*.bkl" % do_get_testdir())] +
+            [str(f) for f in glob("%s/*/*.bkl" % do_get_testdir())])
 
 class InterpreterForTestSuite(bkl.interpreter.Interpreter):
     def generate(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -29,18 +29,20 @@ from glob import glob
 import bkl.parser, bkl.error
 from indir import in_directory
 
-@pytest.fixture(scope='session')
-def testdir():
+def do_get_testdir():
     import test_parsing
     return os.path.dirname(test_parsing.__file__)
 
 @pytest.fixture(scope='session')
+def testdir():
+    return do_get_testdir()
+
 def ast_filenames():
     """
     This fixture returns the list of all .bkl files under tests/parser
     directory that have a matching .ast present.
     """
-    return [str(f) for f in glob("%s/*/*.ast" % testdir())]
+    return [str(f) for f in glob("%s/*/*.ast" % do_get_testdir())]
 
 @pytest.mark.parametrize('ast_file', ast_filenames())
 def test_parser(testdir, ast_file):


### PR DESCRIPTION
This is not supported any more, see

https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly

for the (unconvincing) explanation.

Work around it by splitting each fixture into a helper function and the
actual fixture.

---

The CI build of the previous PR failed because of pytest upgrade: the new version doesn't like how the testing code uses the fixtures, so I had to work around it in this ugly way. I'm pretty sure this is not optimal, but I have no idea what is.