### PR TITLE
Add "allow-undefined" property

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ New Features
 - Allow specifying configurations/platforms for external projects.
 - Support including user-defined property sheets in MSVS 201x toolsets.
 - Add "inputs" property for action targets.
+- Add "allow-undefined" target property.
 
 Bug fixes
 ---------

--- a/extras/vim/bkl.vim
+++ b/extras/vim/bkl.vim
@@ -67,7 +67,7 @@ syn keyword	bklExtProp	file archs configurations contained
 " program/lib/dll ones.
 syn keyword	bklBuildProp	archs basename configurations contained
 syn keyword	bklBuildProp	compiler-options c-compiler-options cxx-compiler-options contained
-syn keyword	bklBuildProp	defines headers includedirs libdirs libs link-options outputdir sources pic multithreading contained
+syn keyword	bklBuildProp	allow-undefined defines headers includedirs libdirs libs link-options outputdir sources pic multithreading contained
 
 syn keyword	bklBool 	false true contained
 syn region	bklBoolRHS	matchgroup=Normal start="= *" end=";" contains=bklBool contained

--- a/src/bkl/plugins/native.py
+++ b/src/bkl/plugins/native.py
@@ -203,6 +203,24 @@ class NativeCompiledType(TargetType):
                      latter could be linked into a shared lib too) are linked
                      with -fPIC and executables are not.
                      """),
+            Property("allow-undefined",
+                 type=BoolType(),
+                 default=lambda target: target.type.link_allow_undefined,
+                 inheritable=True,
+                 doc="""
+                     Allow undefined symbols when linking.
+
+                     By default, all symbols must be defined when linking the
+                     target (even if it is a shared library, for which
+                     undefined symbols are traditionally allowed by default
+                     under Unix), however loadable modules may need to contain
+                     references to symbols in the program loading them that
+                     can't be resolved at the link time and for them this
+                     property may need to be set to ``false``.
+
+                     Note that currently this property is only supported by
+                     "gnu" toolset and is silently ignored by all the others.
+                     """),
             Property("multithreading",
                  type=BoolType(),
                  default=True,
@@ -220,6 +238,8 @@ class NativeCompiledType(TargetType):
         ]
 
     use_pic_by_default = True
+
+    link_allow_undefined = False
 
     def target_file(self, toolset, target):
         """

--- a/src/bkl/plugins/native.py
+++ b/src/bkl/plugins/native.py
@@ -205,7 +205,7 @@ class NativeCompiledType(TargetType):
                      """),
             Property("allow-undefined",
                  type=BoolType(),
-                 default=lambda target: target.type.link_allow_undefined,
+                 default=False,
                  inheritable=True,
                  doc="""
                      Allow undefined symbols when linking.
@@ -238,8 +238,6 @@ class NativeCompiledType(TargetType):
         ]
 
     use_pic_by_default = True
-
-    link_allow_undefined = False
 
     def target_file(self, toolset, target):
         """


### PR DESCRIPTION
This is useful for loadable modules, notably Python extensions, that are
supposed to reference the symbols of the Python interpreter loading them
which can't be resolved at link-time.

See commit 5d30b64f524b56e1e7e5b9e9f7dcfd6230b5fb98 for more context.

---

For even more context, since Python 3.8 `python3-config --ldflags` doesn't return any libraries to link with any longer and, in any case, we don't want to link with `libpython3.x` because this prevents the module from being used by the versions of Python different from `x`, even if it's otherwise possible due to only using limited Python API in the module (under MSW this is achieved by linking with version-independent `python3.lib`, but there is no `libpython3.so` under Unix). So we really can't use -z defs` here and undoing its addition with `-z undefs` doesn't work everywhere because this option has only been added in the relatively recent binutils 2.31 version, and hence we really need something like this option.

As usual, if you have any better suggestions for its name or implementations, please let me know. TIA!