### PR TITLE
Add MSVS 2019 toolset support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@ v1.2.6 (????-??-??)
 New Features
 ------------
 
-- Add MSVS 2015 and 2017 toolsets support.
+- Add MSVS 2015, 2017 and 2019 toolsets support.
 - Allow specifying configurations/platforms for external projects.
 - Support including user-defined property sheets in MSVS 201x toolsets.
 - Add "inputs" property for action targets.

--- a/extras/vim/bkl.vim
+++ b/extras/vim/bkl.vim
@@ -33,7 +33,7 @@ syn keyword	bklGlobalStat	configuration
 syn keyword	bklGlobalStat	setting
 syn keyword	bklGlobalProp	toolsets
 syn keyword	bklGlobalProp	configurations
-syn match	bklGlobalProp	"\<vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\).generate-solution\ze *=" nextgroup=bklBoolRHS skipwhite
+syn match	bklGlobalProp	"\<vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\|2019\).generate-solution\ze *=" nextgroup=bklBoolRHS skipwhite
 syn keyword	bklCommonProp	vs2003.solutionfile
 syn keyword	bklCommonProp	vs2005.solutionfile
 syn keyword	bklCommonProp	vs2008.solutionfile
@@ -42,6 +42,7 @@ syn keyword	bklCommonProp	vs2012.solutionfile
 syn keyword	bklCommonProp	vs2013.solutionfile
 syn keyword	bklCommonProp	vs2015.solutionfile
 syn keyword	bklCommonProp	vs2017.solutionfile
+syn keyword	bklCommonProp	vs2019.solutionfile
 syn keyword	bklCommonProp	gnu.makefile gnu-osx.makefile gnu-suncc.makefile
 
 " Properties common to absolutely all targets.
@@ -54,8 +55,9 @@ syn keyword	bklCommonProp	vs2012.guid vs2012.projectfile contained
 syn keyword	bklCommonProp	vs2013.guid vs2013.projectfile contained
 syn keyword	bklCommonProp	vs2015.guid vs2015.projectfile contained
 syn keyword	bklCommonProp	vs2017.guid vs2017.projectfile contained
+syn keyword	bklCommonProp	vs2019.guid vs2019.projectfile contained
 syn keyword	bklCommonProp	vs.property-sheets contained
-syn match	bklCommonProp	"vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\)\.option\(\.\w\+\)\{1,2}" contained
+syn match	bklCommonProp	"vs\(2003\|2005\|2008\|2010\|2012\|2013\|2015\|2017\|2019\)\.option\(\.\w\+\)\{1,2}" contained
 
 " Properties that can occur inside action targets only.
 syn keyword	bklActionProp	commands inputs outputs contained

--- a/src/bkl/plugins/external.py
+++ b/src/bkl/plugins/external.py
@@ -190,12 +190,14 @@ class VSExternalProject200x(VSExternalProjectBase):
 
 class VSExternalProject201x(VSExternalProjectBase):
     """
-    Wrapper around VS 2010/2012/2013/2015 project files.
+    Wrapper around VS 201x project files.
     """
     @memoized_property
     def version(self):
         v = self.xml.get("ToolsVersion")
-        if v == "15.0":
+        if v == "16.0":
+            return 16
+        elif v == "15.0":
             return 15
         elif v == "14.0":
             return 14

--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -61,7 +61,7 @@ class VS2010Project(VSProjectBase):
 
 
 class VS201xToolsetBase(VSToolsetBase):
-    """Base class for VS2010, VS2012, VS2013, VS2015 and VS2017 toolsets."""
+    """Base class for VS2010, VS2012, VS2013, VS2015, VS2017 and VS2019 toolsets."""
 
     #: XML formatting class
     XmlFormatter = VS201xXmlFormatter
@@ -781,3 +781,50 @@ class VS2017Toolset(VS201xToolsetBase):
     tools_version = "15.0"
     Solution = VS2017Solution
     Project = VS2017Project
+
+
+class VS2019Solution(VS2010Solution):
+    format_version = "12.00"
+    human_version = "16"
+
+    def write_header(self, file):
+        super(VS2019Solution, self).write_header(file)
+        file.write("VisualStudioVersion = 16.0.29020.237\n")
+        file.write("MinimumVisualStudioVersion = 10.0.40219.1\n")
+
+
+class VS2019Project(VS2010Project):
+    version = 16
+
+
+class VS2019Toolset(VS201xToolsetBase):
+    """
+    Visual Studio 2019.
+
+
+    Special properties
+    ------------------
+    This toolset supports the same special properties that
+    :ref:`ref_toolset_vs2010`. The only difference is that they are prefixed
+    with ``vs2019.option.`` instead of ``vs2010.option.``, i.e. the nodes are:
+
+      - ``vs2019.option.Globals.*``
+      - ``vs2019.option.Configuration.*``
+      - ``vs2019.option.*`` (this is the unnamed ``PropertyGroup`` with
+        global settings such as ``TargetName``)
+      - ``vs2019.option.ClCompile.*``
+      - ``vs2019.option.ResourceCompile.*``
+      - ``vs2019.option.Link.*``
+      - ``vs2019.option.Lib.*``
+      - ``vs2019.option.Manifest.*``
+
+    """
+
+    name = "vs2019"
+
+    version = 16
+    proj_versions = [10, 11, 12, 14, 15, 16]
+    platform_toolset = "v142"
+    tools_version = "16.0"
+    Solution = VS2019Solution
+    Project = VS2019Project

--- a/tests/projects/hello_world/hello_world.bkl
+++ b/tests/projects/hello_world/hello_world.bkl
@@ -1,4 +1,4 @@
-toolsets = gnu gnu-osx gnu-suncc vs2003 vs2005 vs2008 vs2010 vs2012 vs2013 vs2015 vs2017;
+toolsets = gnu gnu-osx gnu-suncc vs2003 vs2005 vs2008 vs2010 vs2012 vs2013 vs2015 vs2017 vs2019;
 
 vs2003.solutionfile = hello_world_vs2003.sln;
 vs2005.solutionfile = hello_world_vs2005.sln;
@@ -8,6 +8,7 @@ vs2012.solutionfile = hello_world_vs2012.sln;
 vs2013.solutionfile = hello_world_vs2013.sln;
 vs2015.solutionfile = hello_world_vs2015.sln;
 vs2017.solutionfile = hello_world_vs2017.sln;
+vs2019.solutionfile = hello_world_vs2019.sln;
 
 program hello {
     archs = x86 x86_64;
@@ -22,4 +23,5 @@ program hello {
     vs2013.projectfile = hello_vs2013.vcxproj;
     vs2015.projectfile = hello_vs2015.vcxproj;
     vs2017.projectfile = hello_vs2017.vcxproj;
+    vs2019.projectfile = hello_vs2019.vcxproj;
 }

--- a/tests/projects/hello_world/hello_world.model
+++ b/tests/projects/hello_world/hello_world.model
@@ -1,6 +1,6 @@
 module {
   variables {
-    toolsets = [gnu, gnu-osx, gnu-suncc, vs2003, vs2005, vs2008, vs2010, vs2012, vs2013, vs2015, vs2017]
+    toolsets = [gnu, gnu-osx, gnu-suncc, vs2003, vs2005, vs2008, vs2010, vs2012, vs2013, vs2015, vs2017, vs2019]
     vs2003.solutionfile = @top_srcdir/hello_world_vs2003.sln
     vs2005.solutionfile = @top_srcdir/hello_world_vs2005.sln
     vs2008.solutionfile = @top_srcdir/hello_world_vs2008.sln
@@ -9,6 +9,7 @@ module {
     vs2013.solutionfile = @top_srcdir/hello_world_vs2013.sln
     vs2015.solutionfile = @top_srcdir/hello_world_vs2015.sln
     vs2017.solutionfile = @top_srcdir/hello_world_vs2017.sln
+    vs2019.solutionfile = @top_srcdir/hello_world_vs2019.sln
   }
   targets {
     program hello {
@@ -22,6 +23,7 @@ module {
       vs2013.projectfile = @top_srcdir/hello_vs2013.vcxproj
       vs2015.projectfile = @top_srcdir/hello_vs2015.vcxproj
       vs2017.projectfile = @top_srcdir/hello_vs2017.vcxproj
+      vs2019.projectfile = @top_srcdir/hello_vs2019.vcxproj
       sources {
         file @top_srcdir/hello.c
       }

--- a/tests/test_model/properties/set_toolsets_bad.model
+++ b/tests/test_model/properties/set_toolsets_bad.model
@@ -1,2 +1,2 @@
 ERROR:
-properties/set_toolsets_bad.bkl:1:11: variable "toolsets" (list of toolsets): expression "nonexistent" is not a valid toolset value: must be one of "gnu", "gnu-osx", "gnu-suncc", "vs2003", "vs2005", "vs2008", "vs2010", "vs2012", "vs2013", "vs2015", "vs2017"
+properties/set_toolsets_bad.bkl:1:11: variable "toolsets" (list of toolsets): expression "nonexistent" is not a valid toolset value: must be one of "gnu", "gnu-osx", "gnu-suncc", "vs2003", "vs2005", "vs2008", "vs2010", "vs2012", "vs2013", "vs2015", "vs2017", "vs2019"


### PR DESCRIPTION
This is identical to the changes done for adding MSVS 2017, except that
it combines the changes of 1ce39c7f87fc4b33929fec6f88aab865381f5bb5 and
42a8f058f643debd9666c0731e69a49646d59ce7 into a single commit.