### PR TITLE
Make vs.property-sheets inheritable to allow defining it globally

### DIFF
--- a/src/bkl/plugins/vs201x.py
+++ b/src/bkl/plugins/vs201x.py
@@ -79,7 +79,7 @@ class VS201xToolsetBase(VSToolsetBase):
             Property("vs.property-sheets",
                      type=ListType(PathType()),
                      default=bkl.expr.NullExpr(),
-                     inheritable=False,
+                     inheritable=True,
                      doc="""
                          May contain paths to one or more property sheets files
                          that will be imported from the generated project if they

--- a/tests/projects/msvs/properties.bkl
+++ b/tests/projects/msvs/properties.bkl
@@ -1,0 +1,11 @@
+toolsets = vs2017;
+
+vs.property-sheets = common.props;
+
+program hello {
+    vs.property-sheets += hello.props;
+}
+
+program bye {
+    vs.property-sheets = bye; // override common.props
+}

--- a/tests/projects/msvs/properties.model
+++ b/tests/projects/msvs/properties.model
@@ -1,0 +1,14 @@
+module {
+  variables {
+    toolsets = [vs2017]
+    vs.property-sheets = [@top_srcdir/common.props]
+  }
+  targets {
+    program hello {
+      vs.property-sheets = [@top_srcdir/common.props, @top_srcdir/hello.props]
+    }
+    program bye {
+      vs.property-sheets = [@top_srcdir/bye]
+    }
+  }
+}


### PR DESCRIPTION
It can be very useful to have a property sheet with common compilation
options, which is applied to all the generated projects, so allow using
vs.properties-sheets at the global level to do it by making it
inheritable.

Also add a simple test checking that this works as expected.

---

I'm relatively confident that this does what I want, but I'd appreciate if you could confirm that it's not completely stupid to do it like this. TIA!