### PR TITLE
Allow overriding the DLL installation directory

### DIFF
--- a/rules/makefile.bkl
+++ b/rules/makefile.bkl
@@ -760,16 +760,18 @@
         </define-tag>
 
         <define-tag name="install-to" rules="dll">
+            <set var="__dllinstdir">$(nativePaths(value))</set>
+
             <modify-target target="install_$(id)">
                 <command>
                     $(INSTALL_DATA) $(ref('__targetdir',id))$(ref('__linkname',id)) $(DESTDIR)$(nativePaths(value))
-                    $(INSTALL_PROGRAM) $(ref('__targetdir',id))$(ref('__targetname',id)) $(DESTDIR)$(nativePaths(value))
+                    $(INSTALL_PROGRAM) $(ref('__targetdir',id))$(ref('__targetname',id)) $(DESTDIR)$(ref('__dllinstdir',id))
                 </command>
             </modify-target>
             <modify-target target="uninstall_$(id)">
                 <command>
                     $(UNINSTALL_DATA) $(DESTDIR)$(nativePaths(value))$(DIRSEP)$(ref('__linkname',id))
-                    $(UNINSTALL_PROGRAM) $(DESTDIR)$(nativePaths(value))$(DIRSEP)$(ref('__targetname',id))
+                    $(UNINSTALL_PROGRAM) $(DESTDIR)$(ref('__dllinstdir',id))$(DIRSEP)$(ref('__targetname',id))
                 </command>
             </modify-target>
         </define-tag>


### PR DESCRIPTION
This is useful to install DLLs in $(bindir) when using autoconf, rather
than in $(libdir), as it is done now.

Ideal would be to behave correctly by default, but it's not clear how
could this be done because <install-to> takes only a single parameter
and we need 2 directories, so rely on the hack with __dllinstdir
variable that needs to be set to the right value in the target using
<install-to>.

---

This is ugly but allows to do
```diff
diff --git a/build/bakefiles/common.bkl b/build/bakefiles/common.bkl
index 62748bbb32..c01b473f76 100644
--- a/build/bakefiles/common.bkl
+++ b/build/bakefiles/common.bkl
@@ -764,6 +764,9 @@ $(TAB)cl /EP /nologo "$(DOLLAR)(InputPath)" > "$(SETUPHDIR)\wx\msw\rcdefs.h"

     <template id="wx_dll_b" template="wx_lib_b">
         <set var="WXDLLNAME">$(wxwin.mkDllName(wxid))</set>
+        <if cond="FORMAT=='autoconf'">
+            <set var="__dllinstdir">$(DLLDIR)</set>
+        </if>
         <dllname>$(WXDLLNAME)</dllname>
         <version>$(WX_VERSION)</version>
         <so_version>$(WXSOVERSION)</so_version>
```
in wx to finally solve [this ticket](https://trac.wxwidgets.org/ticket/14601), see https://github.com/wxWidgets/wxWidgets/pull/2161, so if you don't terribly mind, I'll commit this and this in wx.

FWIW I had initially started doing this in wx only by defining my own `install-wx-lib` tag, but this needs copying too much from bkl sources and was too messy.