### PR TITLE
Recognize "arm64" as a valid arch value too

### DIFF
--- a/src/bkl/plugins/gnu.py
+++ b/src/bkl/plugins/gnu.py
@@ -38,6 +38,7 @@ from bkl.error import Error
 
 # GCC flags for supported architectures:
 OSX_ARCH_FLAGS = {
+    'arm64'  : '-arch arm64',
     'x86'    : '-arch i386',
     'x86_64' : '-arch x86_64',
 }

--- a/src/bkl/plugins/native.py
+++ b/src/bkl/plugins/native.py
@@ -144,7 +144,7 @@ class NativeCompiledType(TargetType):
                      executables that use the library.
                      """),
             Property("archs",
-                 type=ListType(EnumType("architecture", ["x86", "x86_64"])),
+                 type=ListType(EnumType("architecture", ["arm64", "x86", "x86_64"])),
                  default=NullExpr(),
                  inheritable=True,
                  doc="""


### PR DESCRIPTION
This is useful at least with gnu-osx toolset.

I've somehow forgot to submit this, but I had to do it to build the native binary of a project using bkl on a M1 Mac.

FWIW it seems to work fine.