### PR TITLE
Allow predefining WXRC variable or setting when using wx plugin

### DIFF
--- a/src/bkl/plugins/wxwidgets.py
+++ b/src/bkl/plugins/wxwidgets.py
@@ -28,7 +28,7 @@ wxWidgets library support.
 
 from bkl.api import FileCompiler, FileType
 from bkl.compilers import CxxFileType
-from bkl.expr import LiteralExpr, ConcatExpr
+from bkl.expr import LiteralExpr, ConcatExpr, ReferenceExpr
 
 
 class XRCFileType(FileType):
@@ -46,9 +46,15 @@ class WXRCCompiler(FileCompiler):
     out_type = CxxFileType.get()
 
     def commands(self, toolset, target, input, output):
+        if target.resolve_variable("WXRC"):
+            wxrc_expr = ReferenceExpr("WXRC", target)
+        else:
+            wxrc_expr = LiteralExpr("wxrc")
+
         # FIXME: make this easier to write with parsing
         cmd = ConcatExpr([
-                    LiteralExpr("wxrc --cpp-code -o "),
+                    wxrc_expr,
+                    LiteralExpr(" --cpp-code -o "),
                     output,
                     LiteralExpr(" "),
                     input


### PR DESCRIPTION
Don't hardcode "wxrc" as the name of the wx resource compiler, but use
WXRC variable if it's predefined in the project bakefile.

This allows customizing it using e.g.

    if ($toolset == gnu) {
        setting WXRC {
            default = "`wx-config --utility=wxrc`";
            help = 'Tool for compiling wxWidgets resources.';
        }
    }

---

See #124.